### PR TITLE
Use ICMP pings to check if TV is alive

### DIFF
--- a/framegallery/main.py
+++ b/framegallery/main.py
@@ -44,7 +44,6 @@ async def update_slideshow_periodically(slideshow: Slideshow):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    await frame_connector.open()
     await frame_connector.get_active_item_details()
 
     # Create a database session and run the importer periodically

--- a/poetry.lock
+++ b/poetry.lock
@@ -661,6 +661,17 @@ files = [
 ]
 
 [[package]]
+name = "icmplib"
+version = "3.0.4"
+description = "Easily forge ICMP packets and make your own ping and traceroute."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "icmplib-3.0.4-py3-none-any.whl", hash = "sha256:336b75c6c23c5ce99ddec33f718fab09661f6ad698e35b6f1fc7cc0ecf809398"},
+    {file = "icmplib-3.0.4.tar.gz", hash = "sha256:57868f2cdb011418c0e1d5586b16d1fabd206569fe9652654c27b6b2d6a316de"},
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -1883,4 +1894,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d2ac68a12de82f77c708c61ee5e8b4964dfa94f078bdceae36961c3bb94a608b"
+content-hash = "7019f3280a34761aa07c44acdbdf22816157ffce1c160738c5310a3d3b0011f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pydantic-settings = "^2.6.0"
 pillow = "^11.0.0"
 pillow-heif = "^0.20.0"
 blinker = "^1.8.2"
+icmplib = "^3.0.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.8.0"


### PR DESCRIPTION
This finally resolve the issue of starting the application while the TV is off, or when the TV is turned off (or goes to sleep). Previously this would crash the app as the connection could not be established. With the changes in this PR, a continuous ping process is started that will reconnect to the TV once the IP address becomes reachable. In the meantime it will disable all interaction.