### PR TITLE
Add lazy loading / infiniscroll to the ImageGrid

### DIFF
--- a/ui/src/components/ImageGrid.tsx
+++ b/ui/src/components/ImageGrid.tsx
@@ -1,21 +1,82 @@
 import Grid from '@mui/material/Grid2';
-import React from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import ArtItemCard from "./ArtItemCard";
 import Image from "../models/Image";
+import { Chip, CircularProgress, Divider } from '@mui/material';
+import Container from "@mui/material/Container";
 
 export interface ImageGridProps {
     items: Image[];
 }
 
 function ImageGrid({items}: ImageGridProps) {
+    const [visibleCount, setVisibleCount] = useState(18);
+    const [loading, setLoading] = useState(false);
+    const [allImagesDisplayed, setAllImagesDisplayed] = useState(false);
+
+    const loadMore = useCallback(() => {
+        setLoading(true);
+        setVisibleCount(visibleCount => {
+            const newVisibleCount = visibleCount + 6;
+
+            if (newVisibleCount >= items.length) {
+                setAllImagesDisplayed(newVisibleCount >= items.length);
+            }
+
+            return newVisibleCount;
+        });
+        setLoading(false);
+    }, [items.length]);
+
+    const handleScroll = useCallback(() => {
+        if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight) {
+            return;
+        }
+
+        if (allImagesDisplayed || loading) {
+            return;
+        }
+
+        loadMore();
+    }, [allImagesDisplayed, loading, loadMore]);
+
+    useEffect(() => {
+        window.addEventListener('scroll', handleScroll);
+        return () => window.removeEventListener('scroll', handleScroll);
+    }, [handleScroll]);
+
     return (
-        <Grid container spacing={{xs: 2, md: 3}} columns={{xs: 4, sm: 8, md: 12}}>
-            {items.map((_, index) => (
-                <Grid key={index} size={{xs: 4, sm: 2, md: 2}}>
-                    <ArtItemCard item={items[index]}/>
-                </Grid>
-            ))}
-        </Grid>)
+        <>
+            <Grid container spacing={{xs: 2, md: 3}} columns={{xs: 4, sm: 8, md: 12}}>
+                {items.slice(0, visibleCount).map((item, index) => (
+                    <Grid key={index} size={{xs: 4, sm: 2, md: 2}}>
+                        <ArtItemCard item={item}/>
+                    </Grid>
+                ))}
+            </Grid>
+            {!allImagesDisplayed && (
+                <Container sx={{py: 5, mx: 'auto'}}>
+                    <Divider>
+                        <Chip label="Load more images" size="small" onClick={loadMore}/>
+                    </Divider>
+                </Container>
+            )}
+            {loading && (
+                <Container sx={{py: 5, mx: 'auto'}}>
+                    <Divider>
+                        <CircularProgress/>
+                    </Divider>
+                </Container>
+            )}
+            {allImagesDisplayed && (
+                <Container sx={{py: 5, mx: 'auto'}}>
+                    <Divider>
+                        <Chip label="All images are displayed" size="small"/>
+                    </Divider>
+                </Container>
+            )}
+        </>
+    )
 }
 
 export default ImageGrid;


### PR DESCRIPTION
This prevents that the _entire_ library is loaded at once when the ImageGrid is opened.

Closes #44