### PR TITLE
feat: add GitHub Container Registry support with automated Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,59 @@
+# Git
+.git
+.gitignore
+
+# CI/CD
+.github
+Justfile
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose.yml
+
+# Documentation
+README.md
+CLAUDE.md
+
+# Development files
+.env
+.env.local
+
+# Logs
+logs/
+*.log
+
+# Data directories that should be mounted
+data/
+images/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+.venv/
+.pytest_cache/
+
+# Node.js
+ui/node_modules/
+ui/dist/
+ui/build/
+ui/.env
+ui/coverage/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+coverage/
+.coverage

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,73 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/tmp/.cache/uv \
 FROM python:3.13-slim AS backend
 WORKDIR /app
 COPY --from=builder --chown=1000:1000 /app /app
-COPY --from=frontend-builder --chown=1000:1000 /app/build /app/ui/build
+COPY --from=frontend-builder --chown=1000:1000 /app/dist /app/ui/dist
 RUN mkdir -p /app/logs
 RUN chown 1000:1000 /app/logs && chmod -R u+w /app/logs
 USER 1000

--- a/README.md
+++ b/README.md
@@ -64,25 +64,71 @@ You need to have [uv](https://github.com/astral-sh/uv) installed. `uv` is an ext
 
 ### Running the application via Docker
 
-First build the image with:
+#### Using Pre-built Images from GitHub Container Registry (Recommended)
+
+You can pull and run the latest pre-built image directly from GitHub Container Registry:
+
 ```bash
-docker build -f Dockerfile -t slknijnenburg/framegallery:latest . 
+# Pull the latest image
+docker pull ghcr.io/slknijnenburg/framegallery:latest
+
+# Create directories for data and images
+mkdir -p ./images ./data
+
+# Run the container
+docker run -d --name framegallery \
+  -p 7999:7999 \
+  -v $(pwd)/images:/app/images \
+  -v $(pwd)/data:/app/data \
+  --env-file .env \
+  ghcr.io/slknijnenburg/framegallery:latest
+```
+
+Or using Docker Compose:
+
+```bash
+# Update docker-compose.yml to use the pre-built image
+docker-compose up -d
+```
+
+#### Building Locally
+
+If you prefer to build the image locally:
+
+```bash
+docker build -f Dockerfile -t framegallery:local . 
 ```
 
 Then run it with:
 ```bash
-docker run -it --rm -p 127.0.0.1:7999:7999 -v $(pwd)/images:/app/images -v $(pwd)/data:/app/data slknijnenburg/framegallery:latest
+docker run -it --rm -p 127.0.0.1:7999:7999 -v $(pwd)/images:/app/images -v $(pwd)/data:/app/data framegallery:local
 ```
+
+#### Configuration
 
 On start-up, the app will import all images from the `images` directory and create a database in the `data` directory.
 It will also generate thumbnails for display in the browser for each image, so you'll need to ensure that the images folder is writeable by the container.
 
-In case changes were made to the database schema, migrations will need to be executed manually when running the updated container.
-This can be done with the following command:
+Create a `.env` file with your Samsung TV configuration:
+```bash
+TV_IP_ADDRESS=192.168.1.100
+TV_PORT=8002
+GALLERY_PATH=/app/images
+```
+
+#### Database Migrations
+
+In case changes were made to the database schema, migrations will need to be executed manually when running the updated container:
 
 ```bash
-docker run -it --rm -v $(pwd)/images:/app/images -v $(pwd)/data:/app/data slknijnenburg/framegallery:latest poetry run alembic upgrade head
+docker run -it --rm -v $(pwd)/images:/app/images -v $(pwd)/data:/app/data ghcr.io/slknijnenburg/framegallery:latest uv run alembic upgrade head
 ```
+
+#### Available Image Tags
+
+- `latest` - Latest stable release from the main branch
+- `main` - Latest development build from the main branch  
+- `v1.0.0` - Specific version tags (when available)
 
 #### Image configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,19 @@
 services:
   framegallery:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    # Use pre-built image from GitHub Container Registry
+    # Comment out the next line and uncomment 'build' section to build locally
+    image: ghcr.io/slknijnenburg/framegallery:latest
+    
+    # Build locally (uncomment to use instead of pre-built image)
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    
     ports:
       - "7999:7999"
     volumes:
       - ./images:/app/images
       - ./data:/app/data
- #     - ./logs:/app/logs
+      - ./logs:/app/logs
     env_file: .env
+    restart: unless-stopped


### PR DESCRIPTION
- Create comprehensive Docker build workflow for GitHub Actions
- Support multi-platform builds (linux/amd64, linux/arm64)
- Push to GitHub Container Registry (ghcr.io) automatically
- Add proper tagging strategy (latest, version tags, branch names)
- Include build attestation for security compliance
- Fix Dockerfile to copy frontend build from correct location (dist vs build)
- Add optimized .dockerignore for faster builds
- Update README with detailed Docker usage instructions
- Configure docker-compose.yml to use pre-built images by default
- Support both pre-built images and local building options

Images will be available at:
- ghcr.io/slknijnenburg/framegallery:latest
- ghcr.io/slknijnenburg/framegallery:main
- ghcr.io/slknijnenburg/framegallery:v1.0.0 (for tagged releases)

🤖 Generated with [Claude Code](https://claude.ai/code)