### PR TITLE
Fix URL construction error in TV files service for development mode

### DIFF
--- a/ui/src/services/tvFilesService.ts
+++ b/ui/src/services/tvFilesService.ts
@@ -1,6 +1,17 @@
 import { API_BASE_URL } from '../App';
 import { TvFile, TvCategory, TV_CATEGORIES } from '../models/TvFile';
 
+// Helper function to detect development mode
+const isDevelopmentMode = () => {
+  // Check for Jest environment (when window might not exist)
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  // Check hostname for development - covers both Vite dev server and general localhost usage
+  return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+};
+
 /**
  * Error class for TV-specific errors.
  */
@@ -28,7 +39,10 @@ export const tvFilesService = {
    */
   async getTvFiles(category: TvCategory = TV_CATEGORIES.USER_CONTENT): Promise<TvFile[]> {
     try {
-      const url = new URL(`${API_BASE_URL}/api/tv/files`);
+      // Use direct backend URL in development, relative URL in production
+      const isDevelopment = isDevelopmentMode();
+      const baseUrl = isDevelopment ? 'http://localhost:7999' : API_BASE_URL;
+      const url = new URL('/api/tv/files', baseUrl);
       url.searchParams.set('category', category);
 
       const response = await fetch(url.toString());


### PR DESCRIPTION
## Summary
Fixes the URL construction error that was preventing the `/tv-files` route from working in development mode.

## Problem
- The `tvFilesService.ts` was trying to construct URLs using an empty `API_BASE_URL` string
- This caused "URL constructor: /api/tv/files is not a valid URL" error when accessing the TV files page
- The error prevented users from viewing the TV files list in development

## Solution
- Added `isDevelopmentMode()` helper function to detect localhost environment
- Updated `getTvFiles()` method to use `http://localhost:7999` as base URL in development
- Falls back to `API_BASE_URL` in production environments
- Uses the same development detection pattern as other parts of the app

## Changes
- Modified `ui/src/services/tvFilesService.ts` to handle development vs production URL construction

## Testing
- ✅ Frontend linting passes (ESLint)
- ✅ All relevant tests pass (Jest)
- ✅ URL construction verified to work correctly in development
- ✅ Backend API endpoint responding correctly (503 - TV not connected, as expected)
- ✅ Frontend development server runs without errors

🤖 Generated with [Claude Code](https://claude.ai/code)