### PR TITLE
feat: separate log level for WebSocket keepalive noise

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -8,6 +8,11 @@ tv_client_name="FrameGallery"
 filesystem_refresh_interval=600
 slideshow_interval=180
 log_level=INFO
+# Log level for the WebSocket libraries (websockets/samsungtvws) that power the
+# Samsung Frame connection. Kept separate from log_level because they emit very
+# noisy ping/pong/keepalive messages at DEBUG. Raise to DEBUG only when you need
+# to debug the TV connection itself.
+websocket_log_level=WARNING
 
 # Docker volume mount paths (defaults to relative paths if not specified)
 IMAGES_PATH=./images

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ tv_client_name=FrameGallery   # device name registered on the TV; keep stable to
 gallery_path="./images"
 db_url="sqlite:///./data/framegallery.db"
 log_level=INFO
+# Log level for the WebSocket libraries (websockets/samsungtvws) driving the TV
+# connection. Kept separate from log_level because they emit very noisy
+# ping/pong/keepalive messages at DEBUG. Raise to DEBUG only to debug the TV link.
+websocket_log_level=WARNING
 slideshow_interval=180
 filesystem_refresh_interval=600
 

--- a/framegallery/config.py
+++ b/framegallery/config.py
@@ -20,6 +20,11 @@ class Settings(BaseSettings):
     filesystem_refresh_interval: int = 600
     slideshow_interval: int = 180
     log_level: str = "DEBUG"
+    # Log level for the WebSocket libraries (``websockets``/``samsungtvws``) that
+    # power the Samsung Frame connection. Kept separate from ``log_level`` because
+    # they emit very noisy ping/pong/keepalive messages at DEBUG. Raise to DEBUG
+    # only when debugging the TV connection.
+    websocket_log_level: str = "WARNING"
     images_path: str = "./images"
     data_path: str = "./data"
     logs_path: str = "./logs"
@@ -35,5 +40,9 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-logger = setup_logging(log_level=settings.log_level)
+logger = setup_logging(
+    log_level=settings.log_level,
+    websocket_log_level=settings.websocket_log_level,
+    logs_path=settings.logs_path,
+)
 logger.warning("Settings at boot: %s", settings.model_dump())

--- a/framegallery/frame_connector/frame_connector.py
+++ b/framegallery/frame_connector/frame_connector.py
@@ -28,7 +28,11 @@ if TYPE_CHECKING:
     from framegallery.libraries.manager import LibraryManager
 
 api_version = "4.3.4.0"
-logger = setup_logging(log_level=settings.log_level)
+logger = setup_logging(
+    log_level=settings.log_level,
+    websocket_log_level=settings.websocket_log_level,
+    logs_path=settings.logs_path,
+)
 
 
 class TvNotConnectedError(Exception):

--- a/framegallery/importer2/importer.py
+++ b/framegallery/importer2/importer.py
@@ -14,7 +14,11 @@ from framegallery import crud, database, models
 from framegallery.config import settings
 from framegallery.logging_config import setup_logging
 
-logger = setup_logging(log_level=settings.log_level)
+logger = setup_logging(
+    log_level=settings.log_level,
+    websocket_log_level=settings.websocket_log_level,
+    logs_path=settings.logs_path,
+)
 register_heif_opener()  # HEIF support
 
 

--- a/framegallery/logging_config.py
+++ b/framegallery/logging_config.py
@@ -3,9 +3,23 @@ import sys
 from pathlib import Path
 
 
-def setup_logging(log_level: str = "INFO") -> logging.Logger:
-    """Set up logging for the application, including file and stream handlers."""
-    log_dir = Path("./logs")
+def setup_logging(
+    log_level: str = "INFO",
+    websocket_log_level: str = "WARNING",
+    logs_path: str = "./logs",
+) -> logging.Logger:
+    """
+    Set up logging for the application, including file and stream handlers.
+
+    ``logs_path`` is the directory the ``framegallery.log`` file is written to.
+
+    ``websocket_log_level`` is applied to the WebSocket libraries used for the
+    Samsung Frame connection (``websockets`` and ``samsungtvws``). These emit very
+    verbose ping/pong/keepalive messages at DEBUG level, so they are pinned to a
+    separate level (default ``WARNING``) independently of the app-wide ``log_level``.
+    Raise it to ``DEBUG`` only when you need to debug the TV connection itself.
+    """
+    log_dir = Path(logs_path)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "framegallery.log"
 
@@ -36,5 +50,12 @@ def setup_logging(log_level: str = "INFO") -> logging.Logger:
     logger = logging.getLogger("framegallery")
     logger.setLevel(getattr(logging, log_level.upper(), logging.INFO))
     logger.propagate = True  # Let messages bubble up to root
+
+    # Pin the WebSocket libraries to their own level so their verbose
+    # ping/pong/keepalive DEBUG messages don't flood the logs when the app runs
+    # at DEBUG. They still propagate to the handlers above, but are filtered here.
+    ws_level = getattr(logging, websocket_log_level.upper(), logging.WARNING)
+    for ws_logger_name in ("websockets", "samsungtvws"):
+        logging.getLogger(ws_logger_name).setLevel(ws_level)
 
     return logger

--- a/framegallery/main.py
+++ b/framegallery/main.py
@@ -47,7 +47,11 @@ from framegallery.schemas import ActivePhoto, ConfigResponse, Filter
 from framegallery.slideshow.slideshow import Slideshow
 from framegallery.sse.slideshow_signal_listener import SlideshowSignalSSEListener
 
-logger = setup_logging(log_level=settings.log_level)
+logger = setup_logging(
+    log_level=settings.log_level,
+    websocket_log_level=settings.websocket_log_level,
+    logs_path=settings.logs_path,
+)
 
 background_tasks = set()
 


### PR DESCRIPTION
## Summary

Running the app at `log_level=DEBUG` floods both stdout and `logs/framegallery.log` with WebSocket ping/pong/keepalive messages. These come from the async `websockets` library that drives the Samsung Frame connection — `setup_logging` set the **root** logger to `log_level`, so `websockets` inherited DEBUG and emitted `sent keepalive ping` / `received keepalive pong` on every heartbeat.

This adds a dedicated **`websocket_log_level`** setting (default `WARNING`) that pins the `websockets` and `samsungtvws` loggers independently of the app-wide `log_level`. You can now keep the app at DEBUG without the keepalive spam, and raise `websocket_log_level=DEBUG` only when you actually need to debug the TV connection.

While in `logging_config.py`, also fixed it to honour the existing `logs_path` setting instead of hardcoding `./logs`.

## Changes

- `config.py`: new `websocket_log_level: str = "WARNING"` setting.
- `logging_config.py`: new `websocket_log_level` and `logs_path` params; pins `websockets`/`samsungtvws` loggers; writes the log file under `logs_path`.
- Threaded the new settings through all `setup_logging(...)` call sites (`main.py`, `importer2/importer.py`, `frame_connector/frame_connector.py`).
- Documented the setting in `.env.dist` and `README.md`.

## Testing

- Verified with `log_level=DEBUG, websocket_log_level=WARNING`: app logger stays at DEBUG while `websockets`/`samsungtvws` sit at WARNING (keepalive DEBUG disabled).
- Verified `logs_path` creates/uses a custom directory.
- `ruff check` clean; pre-commit hooks (ruff, pytest) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)