### PR TITLE
feat: selectable upload processors to diagnose TV Art-Mode crashes

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -7,6 +7,20 @@ tv_port=8002
 tv_client_name="FrameGallery"
 filesystem_refresh_interval=600
 slideshow_interval=180
+# Upload-processor strategy for pushing images to the TV (applied at startup;
+# restart to change). One of:
+#   single_async    - default; async WebSocket, one image at a time
+#   sync_thread     - synchronous client in a thread (idle-recycle, Wake-on-LAN, retries)
+#   batch_slideshow - upload a batch once and let the TV's own slideshow rotate them
+# Change this to A/B test which mechanism your TV tolerates without crashing.
+upload_processor=single_async
+# TV MAC address, used by the "sync_thread" processor to Wake-on-LAN before a
+# retry. Optional; find it with `arp -n <tv-ip>`.
+# tv_mac_address=AA:BB:CC:DD:EE:FF
+# "batch_slideshow" processor tuning: how many images to upload in one batch and
+# the TV's own rotation interval in whole minutes.
+batch_size=50
+batch_rotation_minutes=3
 log_level=INFO
 # Log level for the WebSocket libraries (websockets/samsungtvws) that power the
 # Samsung Frame connection. Kept separate from log_level because they emit very

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ log_level=INFO
 websocket_log_level=WARNING
 slideshow_interval=180
 filesystem_refresh_interval=600
+# Upload-processor strategy for pushing images to the TV (applied at startup —
+# restart to change). One of: single_async (default), sync_thread, batch_slideshow.
+# Useful for A/B testing which mechanism your TV tolerates without crashing. See
+# the "Upload processors" section below.
+upload_processor=single_async
 
 # Docker Volume Mount Paths (customize for your setup)
 IMAGES_PATH=./images
@@ -178,6 +183,33 @@ Images with an aspect ratio of 3:2 (e.g. 1920x1280) can also be configured with 
 Images with an aspect ratio of 4:3 (e.g. 1920x1440) can also be configured with a matte. When using "none" the image will be cropped to 1920x1080
 
 It actually seems you can select any matte style for any image, as long the slideshow mode is disabled.
+
+## Upload processors
+
+The way images are pushed to the TV is pluggable, selected at startup with the `upload_processor`
+setting (restart to apply).
+This exists mainly as a diagnostic tool: some Frame TVs crash in Art Mode during uploads/photo
+changes, and switching the mechanism helps isolate the cause.
+
+| `upload_processor` | Behaviour |
+|---|---|
+| `single_async` (default) | Persistent async WebSocket. On each slideshow tick, uploads one image, activates it, and deletes the previously-active image. |
+| `sync_thread` | Same one-image-at-a-time behaviour, but via the synchronous `samsungtvws` client run in a background thread, with idle-connection recycling, Wake-on-LAN before retry, and bounded retries. |
+| `batch_slideshow` | Uploads a batch of images to the TV once and hands rotation to the TV's own slideshow; the app stops pushing an image every interval. |
+
+If you experience TV crashes, try switching from `single_async` to `sync_thread` (or
+`batch_slideshow`) and observe whether the crashes stop.
+
+Related settings:
+
+| Variable | Default | Applies to | Description |
+|---|---|---|---|
+| `tv_mac_address` | *(unset)* | `sync_thread` | TV MAC address; when set, a Wake-on-LAN packet is sent before retrying a failed connection (`arp -n <tv-ip>` to find it). |
+| `batch_size` | `50` | `batch_slideshow` | How many images to upload to the TV in one batch. |
+| `batch_rotation_minutes` | `3` | `batch_slideshow` | The TV's own rotation interval, in whole minutes (the TV API only accepts minutes, so `slideshow_interval` does not apply in this mode). |
+
+In `batch_slideshow` mode the app-driven slideshow loop and the TV auto-cleanup service are
+both suppressed, since the TV owns rotation and the processor manages its own batch.
 
 ## Photo Libraries
 

--- a/docs/alternative-systems/docent-feature-comparison.md
+++ b/docs/alternative-systems/docent-feature-comparison.md
@@ -1,0 +1,134 @@
+# Docent (danmunz/docent) vs. framegallery
+
+A feature and architecture comparison against the open-source
+[`danmunz/docent`](https://github.com/danmunz/docent) project, which targets the same goal as
+framegallery: getting a personal photo/art library onto a Samsung "The Frame" TV in Art Mode.
+
+Analysis performed 2026-07-16 against the `main` branch of the GitHub repository (Docent v1.0.1).
+
+## What it is, in one line
+
+Docent is a **long-running async FastAPI server** (much like framegallery) whose defining bet is
+a rich **AI art-curation layer** — reverse-image identification, LLM analysis, and weather-aware
+recommendations — bolted onto a polished single-file "museum" web UI, with **no database** (all
+state in JSON files and the TV's own storage) and **no app-managed slideshow** (it defers rotation
+to the TV or to explicit user/AI clicks).
+
+Of the three alternative systems reviewed so far, Docent is architecturally the **closest** to
+framegallery (async FastAPI, persistent connection, uploads to TV storage) while being the
+**furthest** on feature philosophy (AI curation vs. filter-driven automation).
+
+## Feature overview of Docent
+
+| Area | What it does |
+|---|---|
+| **Core model** | "Send any image to your Frame with one click." Browse gallery → "Display on Frame" → `select_image` on the TV |
+| **Gallery UI** | Dense grid, hover titles, lazy thumbnails, lightbox, keyboard nav, year grouping with adaptive bucketing, sticky group nav, collections, bulk ops |
+| **AI art analysis** | Two-stage: **Google Vision** reverse-image identification → **Claude or OpenAI** vision analysis returning artist/title/year/medium/movement/mood/description; auto-analyze on upload; batch analysis; low-confidence Opus escalation |
+| **Atmosphere** | Weather-aware curation — reads local weather (NWS → Open-Meteo fallback), matches gallery mood metadata, presents 3 LLM-curated picks with curator's notes and a variety engine that avoids repeats |
+| **Wikipedia links** | Every metadata field (artist/school/medium/year/title) becomes a client-side Wikipedia link |
+| **Google Drive sync** | Import artwork from a shared Drive folder, with per-sync `file_map` dedup by Drive file ID |
+| **TV controls** | Art-mode toggle, matte selection (shadow box / modern / panoramic), photo filters, favourites, slideshow config passed through to the TV |
+| **Cropping** | Client-side crop editor with 16:9 compliance checking; smart-crop heuristic in the browser + optional Google Vision "crop hint" seed |
+| **Cost tracking** | Per-model token counts and monthly cost estimates in `api_usage.json` |
+| **Ops** | `Docent.command` double-click launcher with setup wizard (macOS), Docker image on GHCR, `/health` endpoint, 90 integration tests |
+| **Persistence** | **JSON files only** (`artwork_meta.json`, `collections.json`, `ai_config.json`, `api_usage.json`, `drive_sync.json`, `atmosphere_history.json`) + `.tv-token` + local `.cache/`. No database (a deliberate guardrail) |
+| **Security posture** | No auth, no multi-user, single TV — same "trusted LAN" posture as the others |
+
+## How Docent manages the TV connection
+
+- **Library:** upstream **`samsungtvws==3.0.4`** from PyPI (not a fork), the **synchronous**
+  `SamsungTVWS` + `.art()` API — *not* the async `SamsungTVAsyncArt`.
+  Blocking calls are pushed off the event loop with `asyncio.to_thread`.
+- **Persistent singleton with idle recycling:** module-level `_tv_conn` / `_tv_art` /
+  `_tv_last_used` globals.
+  `_ensure_tv_connection()` reuses the open art WebSocket but proactively closes and reopens it
+  if idle longer than **30 s** (`TV_CONN_MAX_IDLE`), because the Frame's sockets go stale after
+  ~30–60 s of inactivity and start throwing `BrokenPipeError`.
+- **Serialized access:** a single `asyncio.Lock` (`_tv_lock`) wraps *all* TV I/O via a
+  `_tv_op(fn, *, attempts, timeout)` helper, because the Frame dislikes concurrent connections.
+- **Pairing:** delegated entirely to the library's `token_file=.tv-token` mechanism; first
+  connect pops the on-screen "Allow" prompt on the token-secured port (default **8001**), then
+  the token is reused.
+  No custom two-channel pairing workaround.
+- **Reliability is the headline investment:**
+  - `_tv_op` retries `DOCENT_TV_ATTEMPTS` (default 3) times with `DOCENT_TV_RETRY_DELAY` (2 s)
+    between attempts, each attempt bounded by `asyncio.wait_for` so a hung socket can't hold the
+    lock forever.
+  - On failure it closes the connection and **sends a Wake-on-LAN magic packet** (if
+    `DOCENT_TV_MAC` is set) before retrying — the documented quirk being that the Frame often
+    accepts the TCP socket without answering the art handshake.
+  - `ResponseError` (a definitive TV rejection) is **not** retried.
+  - Uploads use `attempts=1, timeout=120` so a lost response can't cause a duplicate upload.
+  - A **circuit breaker** around batch thumbnail fetches (60 s cooldown after a failure) plus a
+    background thumbnail prefetch task with escalating backoff and a self-rescheduling retry.
+  - Endpoints degrade gracefully — serving stale cache with `"stale": true`, or HTTP 502
+    "Cannot reach TV — is it on and connected?" — when the TV is unreachable.
+
+## How framegallery differs
+
+| Dimension | Docent | framegallery |
+|---|---|---|
+| **Runtime shape** | Long-running **async FastAPI** server | Long-running **async FastAPI** server — *same* |
+| **samsungtvws** | Upstream sync `SamsungTVWS.art()`, run via `to_thread` | **Own git fork**, native async `SamsungTVAsyncArt` + `SamsungTVWSAsyncRemote` |
+| **Connection** | Persistent singleton, **30 s idle recycle**, serialized by `_tv_lock` | Persistent, `start_listening()` + push callbacks; ICMP-ping-driven reconnect |
+| **Pairing quirk** | WoL + retry (handshake quirk); library token file | Recent firmware won't pair on the art channel → pairs on the **remote channel first**, reuses token |
+| **What drives rotation** | **Nothing app-side** — user click, or the TV's native slideshow, or on-demand Atmosphere | **The app** pushes one active image every `slideshow_interval` (180 s) |
+| **Images on the TV** | Uploads all, no cap, lets the Frame hold them | Essentially **one at a time** — upload → activate → delete previous (+ cleanup keeping last 3) |
+| **Image source** | Browser upload + Google Drive import | Pluggable **libraries** — local SQLite gallery **+ Immich** (streamed originals) |
+| **Selection** | Manual, or LLM-curated (Atmosphere), or TV shuffle | **Filter-driven** (react-querybuilder) + weighted-random across libraries |
+| **Persistence** | **JSON files only, no DB** (explicit guardrail) | **SQLite + SQLAlchemy + Alembic** migrations |
+| **AI / curation** | **Extensive** — Vision ID, Claude/OpenAI analysis, weather-aware Atmosphere, cost tracking | None |
+| **Metadata display** | Rich (artist/title/year/medium/movement/mood) + Wikipedia links | None — filename/keyword based |
+| **Cropping** | Client-side editor + browser smart-crop + Google Vision crop-hint seed | Server-side percentage crop + aspect-ratio pipeline (3:2 / 4:3 → 16:9) |
+| **Reliability plumbing** | WoL, bounded-timeout retries, circuit breaker, prefetch backoff, stale-cache fallback | ICMP pinger, reconnect on disconnect, per-op guards, 60 s upload timeout |
+| **Real-time UI** | **None** — REST polling + thumbnail fallback/retry | **SSE** (`/api/slideshow/events`) pushes updates to the React app |
+| **Frontend** | Single-file vanilla HTML/CSS/JS (no build step, by guardrail) | React/TypeScript + Vite + Material-UI |
+| **Matte** | Client-baked crop; `shadowbox_polar` default, plus `change_matte` / photo filters | `none` for 16:9, `shadowbox_black` otherwise; portrait matte `none` |
+| **Auth** | None (by design) | None either |
+
+## Ideas from Docent worth considering for framegallery
+
+Docent's strengths are almost entirely on the **curation and reliability** axes, which is exactly
+where framegallery is thinnest:
+
+1. **AI art analysis + metadata** — the marquee feature.
+   A two-stage Google Vision → Claude/OpenAI pipeline that returns artist/title/year/medium/mood
+   and a description, with cost tracking.
+   framegallery has *no* metadata enrichment at all; even a cut-down "identify + describe" pass
+   would be a real differentiator (and note the close-hauled project does a lighter version of
+   this for location plaques).
+2. **Atmosphere / weather-aware curation** — genuinely novel.
+   Match gallery mood metadata against local weather and surface a few curated picks.
+   This depends on (1) existing first, but it is the kind of feature that gets a project written
+   up in The Verge.
+3. **Connection reliability plumbing** — the most directly portable ideas:
+   - **Proactive idle recycle** (close + reopen after ~30 s idle) to pre-empt the Frame's stale-socket `BrokenPipeError`.
+     framegallery relies on catching the error after the fact.
+   - **Wake-on-LAN before retry.** framegallery already depends on `wakeonlan` but does not
+     import or use it in the connector — Docent shows the pattern (magic packet, gated on a MAC env var).
+   - **A circuit breaker + stale-cache fallback** so a flaky TV degrades gracefully instead of
+     hanging requests.
+4. **A real `/health` endpoint** that checks data-file integrity and directory writability
+   (framegallery's `/api/status` is currently hardcoded to `tv_on=True, art_mode_active=True`).
+5. **Cost tracking for AI usage** — relevant only if framegallery adds AI, but a nice pattern:
+   a per-model pricing table and monthly token/cost accounting.
+
+Conversely, framegallery is ahead on **multi-source libraries (Immich)**, **filter-based automated
+rotation** (Docent has no app-managed slideshow at all — it either relies on the TV's native
+shuffle or requires a manual click), **a real database with migrations**, a **typed React UI**, and
+**SSE real-time updates** — none of which Docent attempts (and several of which it explicitly rules
+out via its "no database, no build step, no auth" guardrails).
+
+## Where the three projects sit relative to each other
+
+- **framegallery** — automated, filter-driven, multi-source (Immich), DB-backed, async, actively
+  pushes one image at a time.
+- **Docent** — manual/AI-curated, single-source (local + Drive), file-backed, async, defers
+  rotation to the TV or the user, with a deep AI layer.
+- **frame-close-hauled (frame-sync)** — automated batch sync, cron-driven CLI, uploads ~50 photos
+  and lets the TV's native slideshow rotate them, with AI location plaques.
+
+Docent and framegallery share the most infrastructure (async FastAPI + persistent connection);
+they diverge on *what the app is for* — Docent curates and identifies art, framegallery automates a
+filtered photo slideshow.

--- a/docs/alternative-systems/frame-close-hauled-feature-comparison.md
+++ b/docs/alternative-systems/frame-close-hauled-feature-comparison.md
@@ -1,0 +1,106 @@
+# frame-sync (close-hauled/frame) vs. framegallery
+
+A feature and architecture comparison against the open-source
+[`close-hauled/frame`](https://gitlab.com/close-hauled/frame) project (aka "frame-sync"),
+which targets the same goal as framegallery: displaying a personal photo library on a
+Samsung "The Frame" TV in Art Mode.
+
+Analysis performed 2026-07-15 against the `master` branch of the GitLab repository.
+
+## What it is, in one line
+
+`frame-sync` is a **cron-driven Python CLI** that periodically uploads a rotating batch of
+~50 processed photos into the TV's own internal storage and lets *the TV's built-in
+slideshow* cycle them, with a thin Flask web UI bolted on for monitoring and manual control.
+
+That is a fundamentally different architecture from framegallery, which is a **long-running
+async service** that pushes one active image at a time on its own timer.
+
+## Feature overview of frame-sync
+
+| Area | What it does |
+|---|---|
+| **Core model** | Keeps an ordered `playlist` in `state.json`; each run evicts photos the TV has already cycled past and refills the TV back up to 50, so with N photos each gets ~`50/N` of the display time |
+| **Rotation** | The **TV's** native slideshow rotates the 50 resident images; the app only swaps the *set* of 50 on a schedule and re-asserts rotation at the end of each run |
+| **TV-progress-aware eviction** | Calls `get_current()` to see what's on screen, evicts only already-seen photos, keeps the current one to avoid a mid-display jump |
+| **AI location lookup** | For photos with no GPS EXIF, sends the image to **Claude Sonnet (vision)** to identify the location; cached by file hash in `location_cache.json` |
+| **Location/date plaques** | Composites a silver "location + date" plaque onto each photo before upload; manual `--set-location` / `--set-date` overrides, re-uploaded on the spot |
+| **Image prep** | EXIF-transpose, landscape → cover-crop to 3840×2160, portrait → scaled to height with `shadowbox_polar` matte |
+| **Web UI (Flask + Gunicorn)** | Dashboard, Now Playing (edit location/date), On TV (the 50-window), Library (Push / Add to frame), Upload, Years histogram, History, Rotate-with-live-log |
+| **Ops** | One-shot CLI (`--yes` for cron), `--evict-all`, `--ensure-rotation` watchdog, `--preview`, systemd unit, Docker, reverse-proxy configs |
+| **State files** | `state.json`, `hash_index.json`, `location_cache.json`, `date_cache.json`, `year_cache.json`, `.tv_token` |
+| **Security posture** | Explicitly **no auth** — meant to sit behind a reverse proxy on a trusted LAN |
+
+## How frame-sync manages the TV connection
+
+- **Library:** upstream **`samsungtvws>=3.0.0`** (PyPI, not forked), the **synchronous**
+  `SamsungTVArt`.
+  But it subclasses it as `FrameTVArt(SamsungTVArt)` to patch firmware quirks — effectively a
+  "fork by subclass."
+- **Sync, per-invocation:** each CLI run creates one `FrameTVArt(host, token_file,
+  timeout=30)`, reuses it for that run, and never explicitly closes it — the process just
+  exits.
+  No daemon, no persistent socket between runs.
+- **Pairing:** delegated entirely to the library via `token_file=.tv_token`; first run pops
+  the "Allow" prompt, later runs are silent.
+- **Reliability is defensive, not connective:**
+  - Uploads run in a `ThreadPoolExecutor(max_workers=1)` with a hard **120 s timeout** plus a
+    heartbeat-logging thread.
+  - Retries up to **3×** on `BrokenPipeError`, re-creating the connection object each time.
+  - Overrides `get_api_version()` to a no-op (the real call *hangs* because the TV's 6-second
+    keepalive pings reset the socket timeout).
+  - `set_slideshow_status` / `set_auto_rotation_status` are **fire-and-forget** (TV returns
+    error −7 / no reply).
+  - Rewrote `_wait_for_d2d()` to treat `notify.sync_server` `status=="finish"` as
+    upload-complete (the stock `image_added` event never arrives on this firmware).
+- **Content tracking:** a persistent **hash → content_id map** in `state.json`, and it
+  discovers each upload's `content_id` by diffing the TV art list before/after the upload
+  (the firmware doesn't return it).
+- **TV off/asleep:** no active power management; swallows errors and returns empty.
+  A separate `--ensure-rotation` watchdog crontab re-enables the slideshow if the TV gets
+  stuck, with a 12h anti-spam cooldown.
+
+## How framegallery differs
+
+| Dimension | frame-sync | framegallery |
+|---|---|---|
+| **Runtime shape** | One-shot CLI on cron + optional Flask UI | Always-on **async FastAPI** service; slideshow is an internal asyncio task |
+| **samsungtvws** | Upstream sync `SamsungTVArt`, patched via subclass | **Own git fork**, async `SamsungTVAsyncArt` + `SamsungTVWSAsyncRemote` |
+| **Connection** | Sync, rebuilt per run, never closed | **Persistent** websocket; `start_listening()` + push callbacks (`go_to_standby`) |
+| **What drives rotation** | **The TV's** native slideshow rotates 50 resident images | **The app** pushes one active image every `slideshow_interval` (180 s) and lets the TV just display it |
+| **Images on the TV** | ~50 uploaded and resident at once | Essentially **one at a time** — upload → activate → delete the previous `content_id` (plus a cleanup service keeping the last 3) |
+| **Image source** | Local disk only | Pluggable **libraries** — local SQLite gallery **+ Immich** (streamed originals), blended with count-proportional weighting |
+| **Selection** | Fair round-robin playlist cursor + shuffle | **Filter-driven** (react-querybuilder filters) + weighted-random across libraries |
+| **Reconnect** | 3× retry on broken pipe, per run | Continuous **ICMP ping** loop re-arms on disconnect; reconnect on `go_to_standby` |
+| **Pairing quirk handled** | `get_api_version` hang; fire-and-forget slideshow | Recent firmware won't pair on the art channel → pairs on the **remote channel first**, reuses token for art channel |
+| **Metadata / plaques** | AI location lookup, composited plaques, Years histogram | None of this — no plaques, no AI, no capture-year UI |
+| **Matte** | `shadowbox_polar` for portrait, `none` landscape | `none` for 16:9, `shadowbox_black` otherwise; crop pipeline for 3:2 / 4:3 |
+| **Real-time UI** | Poll/refresh; live log on Rotate page | **SSE** (`/api/slideshow/events`) pushes updates to the React app |
+| **Auth** | None (by design) | None either — same "trusted LAN" posture |
+
+## Ideas from frame-sync worth considering for framegallery
+
+A few things they do that framegallery genuinely lacks:
+
+1. **AI location + date plaques** — the standout feature.
+   Claude Sonnet vision fills in locations for photos with no GPS, cached by file hash,
+   composited as a plaque.
+   This is a real product differentiator framegallery does not have.
+2. **Years histogram / capture-year browsing** — a nice library-navigation feature.
+3. **Fairness accounting** — they track per-photo upload counts (`rotation_stats.json`) so you
+   can audit that every photo gets equal time.
+   framegallery's weighted-random `pick_photo()` gives no such guarantee (a photo can be
+   picked twice in a row or starved).
+4. **A rotation watchdog** — their `--ensure-rotation` recovers a stuck TV.
+   framegallery's equivalent risk is different (it pushes actively), but it is a reminder that
+   the Frame drops out of the expected state and needs re-asserting.
+
+Conversely, framegallery is architecturally ahead on **multi-source libraries (Immich)**,
+**persistent async connection**, **filter-based selection**, and **SSE real-time updates** —
+all things frame-sync does not attempt.
+
+One thing worth flagging: their "let the TV run its own slideshow over 50 resident images"
+model is much gentler on the TV (one batch upload per night vs. framegallery re-uploading
+every 180 s and deleting).
+If wear-and-tear or reliability issues ever show up from constant upload/delete churn, their
+model is the proven alternative.

--- a/framegallery/auto_cleanup/tv_cleanup_service.py
+++ b/framegallery/auto_cleanup/tv_cleanup_service.py
@@ -3,10 +3,12 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from framegallery.config import settings
+from framegallery.frame_connector.processors import ProcessorKind
 from framegallery.repository.config_repository import ConfigKey, ConfigRepository
 
 if TYPE_CHECKING:
-    from framegallery.frame_connector.frame_connector import FrameConnector
+    from framegallery.frame_connector.processors import UploadProcessor
 
 logger = logging.getLogger("framegallery")
 
@@ -14,7 +16,7 @@ logger = logging.getLogger("framegallery")
 class TvCleanupService:
     """Service for automatically cleaning up old TV files to prevent memory buildup."""
 
-    def __init__(self, frame_connector: "FrameConnector", config_repository: ConfigRepository) -> None:
+    def __init__(self, frame_connector: "UploadProcessor", config_repository: ConfigRepository) -> None:
         self._frame_connector = frame_connector
         self._config_repository = config_repository
         self._cleanup_interval = 3600  # 1 hour in seconds
@@ -44,9 +46,12 @@ class TvCleanupService:
 
     def _is_cleanup_enabled(self) -> bool:
         """Check if auto-cleanup is enabled in the configuration."""
+        # The batch_slideshow processor keeps a whole batch (~50) resident and manages
+        # its own eviction, so the "keep 3 newest" cleanup must never run in that mode.
+        if settings.upload_processor == ProcessorKind.BATCH_SLIDESHOW.value:
+            return False
         try:
-            config = self._config_repository.get_or(ConfigKey.AUTO_CLEANUP_ENABLED, default_value=False)
-            return config.value == "true" if isinstance(config.value, str) else bool(config.value)
+            return self._config_repository.get_bool(ConfigKey.AUTO_CLEANUP_ENABLED, default=False)
         except Exception:
             logger.exception("Error checking auto-cleanup configuration, defaulting to disabled")
             return False

--- a/framegallery/config.py
+++ b/framegallery/config.py
@@ -28,6 +28,21 @@ class Settings(BaseSettings):
     images_path: str = "./images"
     data_path: str = "./data"
     logs_path: str = "./logs"
+    # Which upload-processor strategy to use for pushing images to the TV. One of
+    # "single_async" (default; async WebSocket, one image at a time), "sync_thread"
+    # (synchronous client in a thread, with idle-recycle/Wake-on-LAN/retries), or
+    # "batch_slideshow" (upload a batch once and let the TV rotate them). Applied at
+    # startup; change it and restart to A/B test which mechanism the TV tolerates.
+    upload_processor: str = "single_async"
+    # TV MAC address, used by the "sync_thread" processor to send a Wake-on-LAN
+    # packet before retrying a failed connection. Optional; find it with
+    # `arp -n <tv-ip>`. Only helps when the TV is asleep, not for art-mode crashes.
+    tv_mac_address: str | None = None
+    # "batch_slideshow" processor: how many images to upload to the TV in one batch,
+    # and the TV's own rotation interval in whole minutes (the TV API only accepts
+    # minutes, so the 180s slideshow_interval doesn't apply in this mode).
+    batch_size: int = 50
+    batch_rotation_minutes: int = 3
 
     @property
     def database_path(self) -> str:

--- a/framegallery/dependencies.py
+++ b/framegallery/dependencies.py
@@ -4,7 +4,7 @@ from fastapi import Depends, Request
 from sqlalchemy.orm import Session
 
 from framegallery.database import get_db
-from framegallery.frame_connector.frame_connector import FrameConnector
+from framegallery.frame_connector.processors import UploadProcessor
 from framegallery.libraries.manager import LibraryManager
 from framegallery.repository.config_repository import ConfigRepository
 from framegallery.repository.filter_repository import FilterRepository
@@ -45,6 +45,6 @@ def get_slideshow_instance(
     return Slideshow(library_manager)
 
 
-def get_frame_connector(request: Request) -> FrameConnector:
-    """Get the FrameConnector instance from app state."""
-    return request.app.state.frame_connector
+def get_upload_processor(request: Request) -> UploadProcessor:
+    """Get the active UploadProcessor instance from app state."""
+    return request.app.state.upload_processor

--- a/framegallery/frame_connector/processors/__init__.py
+++ b/framegallery/frame_connector/processors/__init__.py
@@ -1,0 +1,32 @@
+"""
+Pluggable upload processors for pushing images to the Samsung Frame TV.
+
+Each processor implements a different strategy for getting images onto the TV,
+selected at startup via ``settings.upload_processor``. This lets us A/B test the
+upload mechanism to isolate what causes the TV to crash in Art Mode:
+
+- ``single_async``   : the original behaviour (async WebSocket, one image at a
+  time: upload -> activate -> delete previous).
+- ``sync_thread``    : one image at a time, but via the synchronous ``samsungtvws``
+  client run in a thread, with idle-recycle, Wake-on-LAN and bounded retries.
+- ``batch_slideshow``: upload a batch of images once and let the TV's own
+  slideshow rotate them.
+"""
+
+from framegallery.frame_connector.processors.base import (
+    ProcessorKind,
+    TvConnectionTimeoutError,
+    TvNotConnectedError,
+    UploadProcessor,
+    api_version,
+)
+from framegallery.frame_connector.processors.factory import build_processor
+
+__all__ = [
+    "ProcessorKind",
+    "TvConnectionTimeoutError",
+    "TvNotConnectedError",
+    "UploadProcessor",
+    "api_version",
+    "build_processor",
+]

--- a/framegallery/frame_connector/processors/base.py
+++ b/framegallery/frame_connector/processors/base.py
@@ -1,0 +1,257 @@
+"""Interface and shared implementation for the pluggable upload processors."""
+
+from __future__ import annotations
+
+import abc
+import asyncio
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from blinker import signal
+from icmplib import ping
+from samsungtvws.async_remote import SamsungTVWSAsyncRemote
+
+from framegallery.aspect_ratio import get_aspect_ratio
+from framegallery.config import settings
+from framegallery.logging_config import setup_logging
+
+if TYPE_CHECKING:
+    from framegallery.libraries.base import PhotoBytes, PhotoRef
+    from framegallery.libraries.manager import LibraryManager
+
+# The Samsung art-mode API version we report on /api/status. Kept here so all
+# processors (and main.py) share a single source of truth.
+api_version = "4.3.4.0"
+
+logger = setup_logging(
+    log_level=settings.log_level,
+    websocket_log_level=settings.websocket_log_level,
+    logs_path=settings.logs_path,
+)
+
+
+class ProcessorKind(str, Enum):
+    """The available upload-processor strategies (see ``settings.upload_processor``)."""
+
+    SINGLE_ASYNC = "single_async"
+    BATCH_SLIDESHOW = "batch_slideshow"
+    SYNC_THREAD = "sync_thread"
+
+
+class TvNotConnectedError(Exception):
+    """Raised when an operation is attempted while the TV is not connected."""
+
+
+class TvConnectionTimeoutError(TvNotConnectedError):
+    """Raised when the TV connection times out."""
+
+
+class UploadProcessor(abc.ABC):
+    """
+    Strategy that owns the TV connection and applies active-image changes.
+
+    Exactly one processor is built at startup from ``settings.upload_processor``.
+    It owns its own TV connection and is the sole subscriber to the
+    ``active_image_updated`` blinker signal; the other signal receivers
+    (config + SSE listeners) are unaffected by the chosen strategy.
+
+    This base class provides the transport-agnostic machinery shared by every
+    strategy: the ICMP reconnection pinger, token pairing, photo-byte resolution,
+    matte selection, and signal wiring. Subclasses own the actual TV client
+    (async or sync) and implement the abstract methods below.
+    """
+
+    kind: ProcessorKind
+
+    IDEAL_ASPECT_RATIO_WIDTH = 16
+    IDEAL_ASPECT_RATIO_HEIGHT = 9
+
+    def __init__(self, ip_address: str, port: int, library_manager: LibraryManager | None = None) -> None:
+        self._ip_address = ip_address
+        self._port = port
+        # Persist the auth token in the data directory (a mounted volume in
+        # Docker) under a stable filename so it survives restarts.
+        self._token_file = Path(settings.data_path) / "tv-token.txt"
+        # Set during application startup; used to resolve photo bytes from any library.
+        self.library_manager: LibraryManager | None = library_manager
+
+        self._background_tasks: set[asyncio.Task] = set()
+        self._tv_is_online = False
+        self._connected = False
+        self._latest_content_id: str | None = None
+
+        self._active_image_updated_signal = signal("active_image_updated")
+
+        # Check if the TV is available on the network; if so the connection sequence starts.
+        self._start_reconnection_pinger()
+
+    # --- lifecycle ---
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the processor currently has a live, usable TV connection."""
+        return self._connected and self._tv_is_online
+
+    @abc.abstractmethod
+    async def open(self) -> None:
+        """Establish/verify the TV connection and start listening. Idempotent."""
+
+    @abc.abstractmethod
+    async def close(self) -> None:
+        """Tear down the TV connection cleanly. Idempotent."""
+
+    @abc.abstractmethod
+    async def reconnect(self) -> None:
+        """(Re)build the TV client and open the connection."""
+
+    # --- the hot path ---
+
+    @abc.abstractmethod
+    async def apply_active_image(self, photo: PhotoRef) -> None:
+        """
+        React to a request to make ``photo`` the active image.
+
+        - single_async / sync_thread: upload -> select_image -> delete previous.
+        - batch_slideshow: ensure the photo is resident / top up the batch (the TV
+          rotates on its own, so this need not change the on-screen image).
+        """
+
+    # --- generic TV file ops (used by TvCleanupService and the tv_files router) ---
+
+    @abc.abstractmethod
+    async def list_files(self, category: str = "MY-C0002") -> list[dict] | None:
+        """List files on the TV for a category, or None if the TV is unavailable."""
+
+    @abc.abstractmethod
+    async def delete_files(self, content_ids: list[str]) -> dict[str, bool] | None:
+        """Delete files from the TV, returning per-id success, or None if unavailable."""
+
+    # --- optional diagnostics ---
+
+    async def get_active_item_details(self) -> dict | None:
+        """Return the TV's current active item, if the processor supports it."""
+        return None
+
+    # --- shared machinery (transport-agnostic) ---
+
+    def _start_reconnection_pinger(self) -> None:
+        """Start the reconnection timer that reconnects once the TV is reachable."""
+        logger.info("Starting reconnection timer")
+        pinger = asyncio.create_task(self._reconnect_ping())
+        self._background_tasks.add(pinger)
+        pinger.add_done_callback(self._background_tasks.discard)
+
+    async def _reconnect_ping(self) -> None:
+        """Ping the TV until it is online, then reconnect once and stop."""
+        while True:
+            try:
+                response = ping(self._ip_address, count=1, timeout=2, privileged=False)
+                if not response.is_alive:
+                    logger.debug("Ping to %s failed, retrying in 10 seconds", self._ip_address)
+                    self._tv_is_online = False
+                else:
+                    logger.info("Ping to %s successful, reconnecting to the TV.", self._ip_address)
+                    self._tv_is_online = True
+                    await self.reconnect()
+                    break
+            except Exception:
+                logger.exception("Error during ping.")
+            await asyncio.sleep(10)
+
+    async def _ensure_token(self) -> None:
+        """
+        Ensure a valid auth token is persisted before opening the art channel.
+
+        Recent Frame firmware (incl. 2023 models after an OS update) no longer
+        completes first-time pairing on the art-app channel: it just times out
+        with `ms.channel.timeOut`. The token must instead be obtained on the
+        standard remote-control channel, which shows the on-screen "Allow"
+        prompt and returns a token we can reuse for the art-app channel.
+
+        On the very first run the user must accept the prompt on the TV; the
+        token is then written to `self._token_file` and reused silently after.
+        """
+        remote = SamsungTVWSAsyncRemote(
+            host=self._ip_address,
+            port=self._port,
+            name=settings.tv_client_name,
+            token_file=str(self._token_file),
+            timeout=30,
+        )
+        try:
+            # open() triggers the prompt (first run) and persists the token via
+            # the base connection's _check_for_token on ms.channel.connect.
+            await remote.open()
+        finally:
+            await remote.close()
+
+    async def _fetch_photo_bytes(self, photo: PhotoRef) -> PhotoBytes | None:
+        """Resolve the raw image bytes for a photo through the library manager."""
+        if self.library_manager is None:
+            logger.error("Processor has no library_manager; cannot fetch photo bytes.")
+            return None
+        try:
+            return await self.library_manager.fetch_bytes(photo.composite_id)
+        except Exception:
+            logger.exception("Failed to fetch bytes for photo %s", photo.composite_id)
+            return None
+
+    def _transform_file_data(self, file_data: dict) -> dict:
+        """Transform a raw TV file entry into our standardized shape."""
+        content_id = file_data.get("content_id", "Unknown")
+
+        # Determine file type from content_type and other indicators.
+        content_type = file_data.get("content_type", "mobile")
+        file_type = "SAMSUNG_ART" if content_type == "preinstall" else "JPEG"
+
+        file_info = {
+            "content_id": content_id,
+            "category_id": file_data.get("category_id"),
+            "file_name": content_id,
+            "file_type": file_type,
+            "file_size": file_data.get("file_size"),
+            "date": file_data.get("image_date"),
+            "thumbnail_available": True,  # Frame TV typically has thumbnails for all images
+            "matte": file_data.get("matte_id"),
+        }
+
+        # Include any additional metadata fields from the TV.
+        for key, value in file_data.items():
+            if key not in file_info:
+                file_info[key] = value
+
+        return file_info
+
+    def _filter_files_by_category(self, files: list[dict], category: str | None) -> list[dict]:
+        """Filter raw TV files by category and transform them into our shape."""
+        return [
+            self._transform_file_data(file_data)
+            for file_data in files
+            if file_data.get("category_id") == category or category is None
+        ]
+
+    def _compute_matte(self, photo_bytes: PhotoBytes) -> str:
+        """
+        Pick the matte from the final (post-crop) dimensions.
+
+        A 16:9 photo needs no matte; anything else (or unknown dimensions) gets a
+        shadowbox so it isn't stretched.
+        """
+        if photo_bytes.width and photo_bytes.height:
+            aspect_width, aspect_height = get_aspect_ratio(photo_bytes.width, photo_bytes.height)
+            if aspect_width == self.IDEAL_ASPECT_RATIO_WIDTH and aspect_height == self.IDEAL_ASPECT_RATIO_HEIGHT:
+                return "none"
+        return "shadowbox_black"
+
+    def _on_active_image_signal_connect(self) -> None:
+        """Subscribe to the active_image_updated signal."""
+        self._active_image_updated_signal.connect(self._on_active_image_signal)
+
+    def _on_active_image_signal_disconnect(self) -> None:
+        """Unsubscribe from the active_image_updated signal."""
+        self._active_image_updated_signal.disconnect(self._on_active_image_signal)
+
+    async def _on_active_image_signal(self, _: object, active_photo: PhotoRef) -> None:
+        """Blinker signal adapter: route the active_image_updated signal to apply_active_image."""
+        await self.apply_active_image(active_photo)

--- a/framegallery/frame_connector/processors/base.py
+++ b/framegallery/frame_connector/processors/base.py
@@ -83,6 +83,12 @@ class UploadProcessor(abc.ABC):
         self._connected = False
         self._latest_content_id: str | None = None
 
+        # Deduplicate the reconnection-failure logging: a wedged TV can fail every
+        # 10s for hours, so only the first occurrence of a given error gets a full
+        # traceback; repeats are collapsed to a single-line warning.
+        self._reconnect_failures = 0
+        self._last_reconnect_error: str | None = None
+
         self._active_image_updated_signal = signal("active_image_updated")
 
         # Check if the TV is available on the network; if so the connection sequence starts.
@@ -173,6 +179,9 @@ class UploadProcessor(abc.ABC):
 
     async def _reconnect_ping(self) -> None:
         """Ping the TV until it is online, then reconnect once and stop."""
+        # Fresh campaign: the first failure below should always get a full traceback.
+        self._reconnect_failures = 0
+        self._last_reconnect_error = None
         while True:
             try:
                 # icmplib.ping() is blocking, so run it in a worker thread to avoid
@@ -185,10 +194,33 @@ class UploadProcessor(abc.ABC):
                     logger.info("Ping to %s successful, reconnecting to the TV.", self._ip_address)
                     self._tv_is_online = True
                     await self.reconnect()
+                    self._reconnect_failures = 0
+                    self._last_reconnect_error = None
                     break
-            except Exception:
-                logger.exception("Error during ping.")
+            except Exception as exc:  # noqa: BLE001 -- retry loop must survive any connection error
+                self._log_reconnect_failure(exc)
             await asyncio.sleep(10)
+
+    def _log_reconnect_failure(self, exc: Exception) -> None:
+        """
+        Log a reconnection failure, collapsing repeats to avoid traceback spam.
+
+        A wedged TV can reject the connection every 10s indefinitely. The first
+        occurrence of a given error is logged with a full traceback; identical
+        repeats are collapsed to a single-line warning with a running count.
+        """
+        signature = f"{type(exc).__name__}: {exc}"
+        if signature != self._last_reconnect_error:
+            self._last_reconnect_error = signature
+            self._reconnect_failures = 1
+            logger.exception("Error connecting to TV; will keep retrying every 10s.")
+        else:
+            self._reconnect_failures += 1
+            logger.warning(
+                "Still unable to connect to TV after %d attempts (%s); retrying every 10s.",
+                self._reconnect_failures,
+                signature,
+            )
 
     async def _ensure_token(self) -> None:
         """

--- a/framegallery/frame_connector/processors/base.py
+++ b/framegallery/frame_connector/processors/base.py
@@ -77,6 +77,8 @@ class UploadProcessor(abc.ABC):
         self.library_manager: LibraryManager | None = library_manager
 
         self._background_tasks: set[asyncio.Task] = set()
+        self._pinger_task: asyncio.Task | None = None
+        self._shutting_down = False
         self._tv_is_online = False
         self._connected = False
         self._latest_content_id: str | None = None
@@ -133,12 +135,39 @@ class UploadProcessor(abc.ABC):
         """Return the TV's current active item, if the processor supports it."""
         return None
 
+    async def shutdown(self) -> None:
+        """
+        Tear down for application shutdown.
+
+        Cancels the reconnection pinger and closes the connection *without* re-arming
+        the pinger (``close()`` re-arms it during normal operation, but a restart
+        mid-shutdown would leave a pending task and trigger reconnect attempts as the
+        app stops). Call this from the lifespan teardown instead of ``close()``.
+        """
+        self._shutting_down = True
+        for task in list(self._background_tasks):
+            task.cancel()
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        await self.close()
+
     # --- shared machinery (transport-agnostic) ---
 
     def _start_reconnection_pinger(self) -> None:
-        """Start the reconnection timer that reconnects once the TV is reachable."""
+        """
+        Start the reconnection timer that reconnects once the TV is reachable.
+
+        Idempotent: does nothing while shutting down, or if a pinger is already
+        running. ``close()`` and the error paths both call this, so without the
+        guard overlapping calls would spawn multiple concurrent pingers.
+        """
+        if self._shutting_down:
+            return
+        if self._pinger_task is not None and not self._pinger_task.done():
+            return
         logger.info("Starting reconnection timer")
         pinger = asyncio.create_task(self._reconnect_ping())
+        self._pinger_task = pinger
         self._background_tasks.add(pinger)
         pinger.add_done_callback(self._background_tasks.discard)
 
@@ -146,7 +175,9 @@ class UploadProcessor(abc.ABC):
         """Ping the TV until it is online, then reconnect once and stop."""
         while True:
             try:
-                response = ping(self._ip_address, count=1, timeout=2, privileged=False)
+                # icmplib.ping() is blocking, so run it in a worker thread to avoid
+                # stalling the event loop (up to the ping timeout) on every cycle.
+                response = await asyncio.to_thread(ping, self._ip_address, count=1, timeout=2, privileged=False)
                 if not response.is_alive:
                     logger.debug("Ping to %s failed, retrying in 10 seconds", self._ip_address)
                     self._tv_is_online = False

--- a/framegallery/frame_connector/processors/batch_slideshow.py
+++ b/framegallery/frame_connector/processors/batch_slideshow.py
@@ -1,0 +1,143 @@
+"""
+The ``batch_slideshow`` upload processor.
+
+Instead of pushing one active image on every slideshow tick, this uploads a batch of
+images to the TV's internal storage once and hands rotation to the TV's own slideshow
+API. The app then steps back: the periodic slideshow loop is suppressed for this mode
+(see ``_should_push_slideshow_tick`` in main.py), so the TV rotates the resident batch
+on its own timer.
+
+This is the gentlest strategy on the TV (one burst of uploads instead of a constant
+upload/delete churn), which makes it a useful comparison point when diagnosing crashes.
+
+MVP behaviour: evict-all-refill. On connect it wipes MY-C0002, uploads a fresh batch of
+``settings.batch_size`` photos, tracks their ``composite_id -> content_id`` mapping in
+memory, and enables the TV's shuffle rotation. The mapping is not persisted, so a restart
+re-uploads the batch (the batch is disposable). Auto-cleanup is skipped in this mode
+(``TvCleanupService`` would otherwise delete all but the 3 newest).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from framegallery.config import settings
+from framegallery.frame_connector.processors.base import ProcessorKind
+from framegallery.frame_connector.processors.single_async import SingleAsyncProcessor, logger
+
+if TYPE_CHECKING:
+    from framegallery.libraries.base import PhotoRef
+    from framegallery.libraries.manager import LibraryManager
+
+# The TV category for user-uploaded content; also the rotation category (MY-C000{2}).
+_USER_CATEGORY = "MY-C0002"
+_ROTATION_CATEGORY = 2
+
+
+class BatchSlideshowProcessor(SingleAsyncProcessor):
+    """Upload a batch of images once and let the TV's own slideshow rotate them."""
+
+    kind = ProcessorKind.BATCH_SLIDESHOW
+
+    def __init__(self, ip_address: str, port: int, library_manager: LibraryManager | None = None) -> None:
+        super().__init__(ip_address, port, library_manager)
+        # In-memory map of composite_id -> TV content_id for the resident batch.
+        self._resident: dict[str, str] = {}
+
+    async def open(self) -> None:
+        """Connect, refill the batch, and enable the TV's own rotation."""
+        await super().open()
+        if not self._connected:
+            return
+        await self._refill_batch()
+        await self._enable_tv_rotation()
+
+    async def apply_active_image(self, photo: PhotoRef) -> None:
+        """
+        Handle an explicit "show this photo now" request.
+
+        The periodic loop does not call this in batch mode (the TV owns rotation),
+        so this only runs for explicit user selections: ensure the photo is resident
+        (upload if missing) and jump to it.
+        """
+        if not self._connected or not self._tv_is_online:
+            return
+
+        content_id = self._resident.get(photo.composite_id)
+        if content_id is None:
+            content_id = await self._upload_and_track(photo)
+            if content_id is None:
+                return
+
+        await self._activate_image(content_id)
+
+    async def _upload_and_track(self, photo: PhotoRef) -> str | None:
+        """Upload a photo, record it in the resident map, and return its content_id."""
+        photo_bytes = await self._fetch_photo_bytes(photo)
+        if photo_bytes is None:
+            return None
+        data = await self._upload_photo(photo, photo_bytes)
+        if not data or not data.get("content_id"):
+            logger.error("batch_slideshow: upload of %s returned no content_id", photo.composite_id)
+            return None
+        content_id = data["content_id"]
+        self._resident[photo.composite_id] = content_id
+        return content_id
+
+    async def _refill_batch(self) -> None:
+        """Evict everything currently on the TV, then upload a fresh batch."""
+        if self.library_manager is None:
+            logger.error("batch_slideshow: no library_manager; cannot refill batch.")
+            return
+
+        # Evict all current user content so we start from a known-empty window.
+        existing = await self.list_files(_USER_CATEGORY)
+        if existing:
+            content_ids = [f["content_id"] for f in existing if f.get("content_id")]
+            if content_ids:
+                logger.info("batch_slideshow: evicting %d existing images", len(content_ids))
+                await self.delete_files(content_ids)
+        self._resident.clear()
+
+        # Pick and upload up to batch_size unique photos. pick_photo() is weighted-random
+        # and may repeat, so cap the number of attempts to avoid looping forever when the
+        # library is smaller than batch_size.
+        target = settings.batch_size
+        max_attempts = target * 5
+        attempts = 0
+        while len(self._resident) < target and attempts < max_attempts:
+            attempts += 1
+            photo = await self.library_manager.pick_photo()
+            if photo is None:
+                break
+            if photo.composite_id in self._resident:
+                continue
+            await self._upload_and_track(photo)
+
+        logger.info(
+            "batch_slideshow: uploaded %d/%d images (%d attempts)",
+            len(self._resident),
+            target,
+            attempts,
+        )
+
+    async def _enable_tv_rotation(self) -> None:
+        """Turn on the TV's built-in shuffle rotation over the resident batch."""
+        minutes = max(1, settings.batch_rotation_minutes)
+        # Both calls are best-effort: firmwares differ on which rotation API they
+        # honour, so we try both and don't let a rejection abort the batch.
+        try:
+            await self._tv.set_auto_rotation_status(duration=minutes, type=True, category=_ROTATION_CATEGORY)
+        except Exception:  # noqa: BLE001 -- best-effort; log and continue
+            logger.exception("batch_slideshow: set_auto_rotation_status failed")
+        try:
+            await self._tv.set_slideshow_status(duration=minutes, type=True, category=_ROTATION_CATEGORY)
+        except Exception:  # noqa: BLE001 -- best-effort; log and continue
+            logger.exception("batch_slideshow: set_slideshow_status failed")
+
+        # Read the state back so the logs show what the firmware actually accepted.
+        try:
+            status = await self._tv.get_auto_rotation_status()
+            logger.info("batch_slideshow: auto-rotation status now: %s", status)
+        except Exception:  # noqa: BLE001 -- diagnostic read-back only
+            logger.debug("batch_slideshow: could not read back auto-rotation status")

--- a/framegallery/frame_connector/processors/batch_slideshow.py
+++ b/framegallery/frame_connector/processors/batch_slideshow.py
@@ -19,6 +19,7 @@ re-uploads the batch (the batch is disposable). Auto-cleanup is skipped in this 
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from framegallery.config import settings
@@ -26,12 +27,20 @@ from framegallery.frame_connector.processors.base import ProcessorKind
 from framegallery.frame_connector.processors.single_async import SingleAsyncProcessor, logger
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from framegallery.libraries.base import PhotoRef
     from framegallery.libraries.manager import LibraryManager
 
 # The TV category for user-uploaded content; also the rotation category (MY-C000{2}).
 _USER_CATEGORY = "MY-C0002"
 _ROTATION_CATEGORY = 2
+
+# The TV is sluggish right after a batch of uploads, so give it a moment before
+# enabling rotation, then retry the (2s-timeout) calls a few times before giving up.
+_ROTATION_SETTLE_SECONDS = 5
+_ROTATION_ATTEMPTS = 4
+_ROTATION_RETRY_DELAY = 3
 
 
 class BatchSlideshowProcessor(SingleAsyncProcessor):
@@ -122,22 +131,65 @@ class BatchSlideshowProcessor(SingleAsyncProcessor):
         )
 
     async def _enable_tv_rotation(self) -> None:
-        """Turn on the TV's built-in shuffle rotation over the resident batch."""
-        minutes = max(1, settings.batch_rotation_minutes)
-        # Both calls are best-effort: firmwares differ on which rotation API they
-        # honour, so we try both and don't let a rejection abort the batch.
-        try:
-            await self._tv.set_auto_rotation_status(duration=minutes, type=True, category=_ROTATION_CATEGORY)
-        except Exception:  # noqa: BLE001 -- best-effort; log and continue
-            logger.exception("batch_slideshow: set_auto_rotation_status failed")
-        try:
-            await self._tv.set_slideshow_status(duration=minutes, type=True, category=_ROTATION_CATEGORY)
-        except Exception:  # noqa: BLE001 -- best-effort; log and continue
-            logger.exception("batch_slideshow: set_slideshow_status failed")
+        """
+        Turn on the TV's built-in shuffle rotation over the resident batch.
 
-        # Read the state back so the logs show what the firmware actually accepted.
-        try:
-            status = await self._tv.get_auto_rotation_status()
-            logger.info("batch_slideshow: auto-rotation status now: %s", status)
-        except Exception:  # noqa: BLE001 -- diagnostic read-back only
-            logger.debug("batch_slideshow: could not read back auto-rotation status")
+        The library's per-request timeout is short (~2s) and the TV is congested
+        right after an upload burst, so the enable calls often time out (surfacing
+        as an AssertionError inside samsungtvws). We let the TV settle, then retry
+        each call a few times, and finally read the status back to confirm.
+        """
+        minutes = max(1, settings.batch_rotation_minutes)
+
+        # Give the TV a moment to finish digesting the uploads before we ask it to rotate.
+        await asyncio.sleep(_ROTATION_SETTLE_SECONDS)
+
+        # Both calls target the same behaviour via different APIs; firmwares differ on
+        # which one they honour, so we try both. Success on either is enough.
+        auto_ok = await self._enable_rotation_call(
+            "set_auto_rotation_status",
+            lambda: self._tv.set_auto_rotation_status(duration=minutes, type=True, category=_ROTATION_CATEGORY),
+        )
+        slideshow_ok = await self._enable_rotation_call(
+            "set_slideshow_status",
+            lambda: self._tv.set_slideshow_status(duration=minutes, type=True, category=_ROTATION_CATEGORY),
+        )
+
+        confirmed = await self._read_rotation_status()
+        if confirmed is not None:
+            logger.info("batch_slideshow: TV rotation confirmed active: %s", confirmed)
+        elif auto_ok or slideshow_ok:
+            logger.info(
+                "batch_slideshow: rotation enabled (set_auto_rotation_status=%s, set_slideshow_status=%s); "
+                "status read-back unavailable",
+                auto_ok,
+                slideshow_ok,
+            )
+        else:
+            logger.warning(
+                "batch_slideshow: could not enable TV rotation after %d attempts; the batch is uploaded "
+                "but the TV may not be rotating. It often works on the next run once the TV has settled.",
+                _ROTATION_ATTEMPTS,
+            )
+
+    async def _enable_rotation_call(self, name: str, call: Callable[[], Awaitable[object]]) -> bool:
+        """Invoke a rotation-enable coroutine factory with bounded retries; return success."""
+        for attempt in range(1, _ROTATION_ATTEMPTS + 1):
+            try:
+                await call()
+            except Exception as exc:  # noqa: BLE001 -- retry transient TV timeouts (AssertionError etc.)
+                logger.debug("batch_slideshow: %s attempt %d/%d failed: %s", name, attempt, _ROTATION_ATTEMPTS, exc)
+                if attempt < _ROTATION_ATTEMPTS:
+                    await asyncio.sleep(_ROTATION_RETRY_DELAY)
+            else:
+                return True
+        return False
+
+    async def _read_rotation_status(self) -> dict | None:
+        """Read the TV's rotation status back (either API), or None if unavailable."""
+        for getter in (self._tv.get_auto_rotation_status, self._tv.get_slideshow_status):
+            try:
+                return await getter()
+            except Exception:  # noqa: BLE001, S112 -- diagnostic read-back; fall through to the other getter
+                continue
+        return None

--- a/framegallery/frame_connector/processors/batch_slideshow.py
+++ b/framegallery/frame_connector/processors/batch_slideshow.py
@@ -12,9 +12,12 @@ upload/delete churn), which makes it a useful comparison point when diagnosing c
 
 MVP behaviour: evict-all-refill. On connect it wipes MY-C0002, uploads a fresh batch of
 ``settings.batch_size`` photos, tracks their ``composite_id -> content_id`` mapping in
-memory, and enables the TV's shuffle rotation. The mapping is not persisted, so a restart
+memory, and enables the TV's shuffle slideshow. The mapping is not persisted, so a restart
 re-uploads the batch (the batch is disposable). Auto-cleanup is skipped in this mode
 (``TvCleanupService`` would otherwise delete all but the 3 newest).
+
+"Rotation" throughout this module refers to the slideshow cycling through images, NOT
+physical rotation of the TV panel — see ``_enable_tv_rotation`` for the full note.
 """
 
 from __future__ import annotations
@@ -132,7 +135,16 @@ class BatchSlideshowProcessor(SingleAsyncProcessor):
 
     async def _enable_tv_rotation(self) -> None:
         """
-        Turn on the TV's built-in shuffle rotation over the resident batch.
+        Turn on the TV's built-in shuffle slideshow over the resident batch.
+
+        NOTE ON NAMING: despite the name, ``set_auto_rotation_status`` has nothing to
+        do with physically rotating the panel (the motorised auto-rotating wall mount).
+        In Samsung's Art Mode API "auto rotation" means *rotating through the images* —
+        i.e. the slideshow auto-advancing the displayed artwork every N minutes.
+        ``set_auto_rotation_status`` and ``set_slideshow_status`` are two firmware-era
+        names for that same slideshow feature (identical payloads: interval in minutes +
+        shuffle flag + category). Physical panel orientation is a separate, read-only
+        request (``get_current_rotation``) that this app never calls.
 
         The library's per-request timeout is short (~2s) and the TV is congested
         right after an upload burst, so the enable calls often time out (surfacing
@@ -144,8 +156,8 @@ class BatchSlideshowProcessor(SingleAsyncProcessor):
         # Give the TV a moment to finish digesting the uploads before we ask it to rotate.
         await asyncio.sleep(_ROTATION_SETTLE_SECONDS)
 
-        # Both calls target the same behaviour via different APIs; firmwares differ on
-        # which one they honour, so we try both. Success on either is enough.
+        # Both calls enable the same slideshow via different API names; firmwares differ
+        # on which one they honour, so we try both. Success on either is enough.
         auto_ok = await self._enable_rotation_call(
             "set_auto_rotation_status",
             lambda: self._tv.set_auto_rotation_status(duration=minutes, type=True, category=_ROTATION_CATEGORY),

--- a/framegallery/frame_connector/processors/factory.py
+++ b/framegallery/frame_connector/processors/factory.py
@@ -1,0 +1,43 @@
+"""Factory for building the configured upload processor at startup."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from framegallery.frame_connector.processors.base import ProcessorKind, UploadProcessor
+
+if TYPE_CHECKING:
+    from framegallery.libraries.manager import LibraryManager
+
+
+def build_processor(
+    kind: ProcessorKind,
+    ip_address: str,
+    port: int,
+    library_manager: LibraryManager | None = None,
+) -> UploadProcessor:
+    """
+    Build the upload processor for the given kind.
+
+    Imports are local so that unused strategies (and their dependencies) are never
+    imported, and so importing this module stays cheap.
+    """
+    # Imports are local so that unused strategies (and their heavy TV-client deps)
+    # are never imported for a given deployment.
+    if kind == ProcessorKind.SINGLE_ASYNC:
+        from framegallery.frame_connector.processors.single_async import SingleAsyncProcessor  # noqa: PLC0415
+
+        return SingleAsyncProcessor(ip_address, port, library_manager)
+
+    if kind == ProcessorKind.SYNC_THREAD:
+        from framegallery.frame_connector.processors.sync_thread import SyncThreadProcessor  # noqa: PLC0415
+
+        return SyncThreadProcessor(ip_address, port, library_manager)
+
+    if kind == ProcessorKind.BATCH_SLIDESHOW:
+        from framegallery.frame_connector.processors.batch_slideshow import BatchSlideshowProcessor  # noqa: PLC0415
+
+        return BatchSlideshowProcessor(ip_address, port, library_manager)
+
+    msg = f"Unknown upload processor kind: {kind!r}"
+    raise ValueError(msg)

--- a/framegallery/frame_connector/processors/single_async.py
+++ b/framegallery/frame_connector/processors/single_async.py
@@ -1,33 +1,35 @@
 """
-The FrameConnector provides a signal handler for the `active_image_updated` signal, and will
-update the active image on the Frame TV when the signal is emitted.
+The ``single_async`` upload processor.
+
+This is the original FrameGallery behaviour: a persistent async ``SamsungTVAsyncArt``
+WebSocket that, on each ``active_image_updated`` signal, uploads one image, activates
+it (``select_image``), and deletes the previously-active image.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-import os
 import traceback
 import uuid
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import websockets
-from blinker import signal
-from icmplib import ping
 from samsungtvws.async_art import ArtChannelEmitCommand, SamsungTVAsyncArt
-from samsungtvws.async_remote import SamsungTVWSAsyncRemote
 
-from framegallery.aspect_ratio import get_aspect_ratio
 from framegallery.config import settings
+from framegallery.frame_connector.processors.base import (
+    ProcessorKind,
+    TvConnectionTimeoutError,
+    TvNotConnectedError,
+    UploadProcessor,
+)
 from framegallery.logging_config import setup_logging
 
 if TYPE_CHECKING:
     from framegallery.libraries.base import PhotoBytes, PhotoRef
     from framegallery.libraries.manager import LibraryManager
 
-api_version = "4.3.4.0"
 logger = setup_logging(
     log_level=settings.log_level,
     websocket_log_level=settings.websocket_log_level,
@@ -35,42 +37,14 @@ logger = setup_logging(
 )
 
 
-class TvNotConnectedError(Exception):
-    """Exception raised when the TV is not connected."""
+class SingleAsyncProcessor(UploadProcessor):
+    """Push one active image at a time over a persistent async WebSocket."""
 
+    kind = ProcessorKind.SINGLE_ASYNC
 
-class TvConnectionTimeoutError(TvNotConnectedError):
-    """Exception raised when the TV connection times out."""
-
-
-class FrameConnector:
-    """A class that connects to the Frame TV and updates the active image on the TV."""
-
-    IDEAL_ASPECT_RATIO_HEIGHT = 9
-    IDEAL_ASPECT_RATIO_WIDTH = 16
-
-    def __init__(self, ip_address: str, port: int) -> None:
+    def __init__(self, ip_address: str, port: int, library_manager: LibraryManager | None = None) -> None:
+        super().__init__(ip_address, port, library_manager)
         self._tv: SamsungTVAsyncArt | None = None
-        self._ip_address = ip_address
-        self._port = port
-        self._pid = os.getpid()
-        # Persist the auth token in the data directory (a mounted volume in
-        # Docker) under a stable filename so it survives restarts. A per-PID
-        # token file meant the token was never reused and every boot re-paired.
-        self._token_file = Path(settings.data_path) / "tv-token.txt"
-        self._background_tasks = set()
-
-        self._latest_content_id = None
-        self._tv_is_online = False
-        self._connected = False
-
-        # Set during application startup; used to resolve photo bytes from any library.
-        self.library_manager: LibraryManager | None = None
-
-        self._active_image_updated_signal = signal("active_image_updated")
-
-        # Check if the TV is available on the network. If it is, the connection sequence will be started.
-        self._start_reconnection_pinger()
 
     async def open(self) -> None:
         """Open a connection to the TV and start listening to the slideshow update events."""
@@ -87,66 +61,15 @@ class FrameConnector:
             raise TvConnectionTimeoutError from e
 
         self._connected = True
-        self._active_image_updated_signal.connect(self._on_active_image_updated)
+        self._on_active_image_signal_connect()
 
     async def close(self) -> None:
         """Close the connection to the TV, and (re)start the reconnection pinger."""
-        await self._tv.close()
+        if self._tv is not None:
+            await self._tv.close()
         self._connected = False
-        self._active_image_updated_signal.disconnect(self._on_active_image_updated)
+        self._on_active_image_signal_disconnect()
         self._start_reconnection_pinger()
-
-    def _start_reconnection_pinger(self) -> None:
-        """Start the reconnection timer."""
-        logger.info("Starting reconnection timer")
-        pinger = asyncio.create_task(self._reconnect_ping())
-        self._background_tasks.add(pinger)
-        pinger.add_done_callback(self._background_tasks.discard)
-
-    async def _reconnect_ping(self) -> None:
-        """Ping the TV to check if it is online."""
-        while True:
-            try:
-                response = ping(self._ip_address, count=1, timeout=2, privileged=False)
-                if not response.is_alive:
-                    logger.debug("Ping to %s failed, retrying in 10 seconds", self._ip_address)
-                    self._tv_is_online = False
-                else:
-                    logger.info("Ping to %s successful, reconnecting to the TV.", self._ip_address)
-                    self._tv_is_online = True
-                    await self.reconnect()
-                    break
-
-            except Exception:
-                logger.exception("Error during ping.")
-            await asyncio.sleep(10)
-
-    async def _ensure_token(self) -> None:
-        """
-        Ensure a valid auth token is persisted before opening the art channel.
-
-        Recent Frame firmware (incl. 2023 models after an OS update) no longer
-        completes first-time pairing on the art-app channel: it just times out
-        with `ms.channel.timeOut`. The token must instead be obtained on the
-        standard remote-control channel, which shows the on-screen "Allow"
-        prompt and returns a token we can reuse for the art-app channel.
-
-        On the very first run the user must accept the prompt on the TV; the
-        token is then written to `self._token_file` and reused silently after.
-        """
-        remote = SamsungTVWSAsyncRemote(
-            host=self._ip_address,
-            port=self._port,
-            name=settings.tv_client_name,
-            token_file=str(self._token_file),
-            timeout=30,
-        )
-        try:
-            # open() triggers the prompt (first run) and persists the token via
-            # the base connection's _check_for_token on ms.channel.connect.
-            await remote.open()
-        finally:
-            await remote.close()
 
     async def reconnect(self) -> None:
         """Reconnect to the TV."""
@@ -188,8 +111,9 @@ class FrameConnector:
             )
             return bool(self._tv.art_mode)
 
-    async def _on_active_image_updated(self, _: object, active_photo: PhotoRef) -> None:  # noqa: PLR0911, C901
-        logger.info("Updating active image on TV (via slideshow signal): %s", active_photo.composite_id)
+    async def apply_active_image(self, photo: PhotoRef) -> None:  # noqa: PLR0911, C901
+        """Upload the given photo to the TV, activate it, and delete the previous one."""
+        logger.info("Updating active image on TV (via slideshow signal): %s", photo.composite_id)
 
         # Upload the image to the TV
         try:
@@ -200,11 +124,11 @@ class FrameConnector:
                 logger.debug("TV is not in art-mode, skipping image update.")
                 return
 
-            logger.debug("_on_active_image_updated: TV connected, uploading image")
-            photo_bytes = await self._fetch_photo_bytes(active_photo)
+            logger.debug("apply_active_image: TV connected, uploading image")
+            photo_bytes = await self._fetch_photo_bytes(photo)
             if photo_bytes is None:
                 return
-            data = await self._upload_photo(active_photo, photo_bytes)
+            data = await self._upload_photo(photo, photo_bytes)
         except websockets.exceptions.ConnectionClosedError:
             logger.exception("Connection to TV is closed, perhaps the TV is off?")
             await self.close()
@@ -236,61 +160,13 @@ class FrameConnector:
         else:
             logger.error("Slideshow image upload failed, data is None.")
 
-    async def activate_image(self, photo: PhotoRef) -> None:
-        """Activate a photo on the Frame TV, uploading if necessary."""
-        logger.info("Activating photo: %s via explicit request.", photo.composite_id)
-
-        # Check connection status first
-        if not self._connected or not self._tv_is_online:
-            logger.error("TV not connected, cannot activate image.")
-            return
-
-        photo_bytes = await self._fetch_photo_bytes(photo)
-        if photo_bytes is None:
-            logger.error("Could not fetch bytes for photo %s", photo.composite_id)
-            return
-
-        # Always upload the photo (potentially cropped) to get the latest content_id
-        logger.info("Uploading photo %s to ensure it's available...", photo.composite_id)
-
-        uploaded_data = await self._upload_photo(photo, photo_bytes)
-        if not uploaded_data:
-            logger.error("Upload failed for photo %s", photo.composite_id)
-            return
-
-        content_id = uploaded_data.get("content_id")
-
-        if content_id:
-            logger.info("Upload successful (content_id: %s), activating image...", content_id)
-            await self._activate_image(content_id)
-        else:
-            logger.error("Upload completed but did not return a content_id.")
-
-    async def _fetch_photo_bytes(self, photo: PhotoRef) -> PhotoBytes | None:
-        """Resolve the raw image bytes for a photo through the library manager."""
-        if self.library_manager is None:
-            logger.error("FrameConnector has no library_manager; cannot fetch photo bytes.")
-            return None
-        try:
-            return await self.library_manager.fetch_bytes(photo.composite_id)
-        except Exception:
-            logger.exception("Failed to fetch bytes for photo %s", photo.composite_id)
-            return None
-
     async def _upload_photo(self, photo: PhotoRef, photo_bytes: PhotoBytes) -> dict | None:
         """Upload photo bytes to TV and return the uploaded file details as provided by the television."""
         logger.info("Uploading photo %s to TV", photo.composite_id)
 
         file_data = photo_bytes.data
         file_type = photo_bytes.file_type_suffix
-
-        # Pick the matte from the final (post-crop) dimensions; a 16:9 photo needs no matte,
-        # anything else (or unknown dimensions) gets a shadowbox so it isn't stretched.
-        matte = "shadowbox_black"
-        if photo_bytes.width and photo_bytes.height:
-            aspect_width, aspect_height = get_aspect_ratio(photo_bytes.width, photo_bytes.height)
-            if aspect_width == self.IDEAL_ASPECT_RATIO_WIDTH and aspect_height == self.IDEAL_ASPECT_RATIO_HEIGHT:
-                matte = "none"
+        matte = self._compute_matte(photo_bytes)
 
         logger.info(
             "Going to upload %s with file_type %s and filesize: %d",
@@ -327,58 +203,10 @@ class FrameConnector:
         logger.info("Deleting image %s", content_id)
         await self._tv.delete(content_id)
 
-    async def tv_keepalive(self) -> None:
-        """Keep WebSocket connection alive."""
-        while True:
-            if not self._tv.connection:
-                logger.warning("Should be reconnecting to TV")
-            else:
-                logger.warning("No need to reconnect to TV")
-            await asyncio.sleep(10)  # Adjust interval as needed
-
     async def go_to_standby(self) -> None:
         """Close the connector when the TV goes to standby."""
         logger.info("TV is going to standby")
         await self.close()
-
-    def _transform_file_data(self, file_data: dict) -> dict:
-        """Transform TV file data into standardized format."""
-        # Extract content ID for display name
-        content_id = file_data.get("content_id", "Unknown")
-
-        # Generate file_name from content_id (e.g., "MY_F33145" -> "MY_F33145")
-        file_name = content_id
-
-        # Determine file type from content_type and other indicators
-        content_type = file_data.get("content_type", "mobile")
-        # Default to JPEG for mobile uploads, Samsung Art for preinstalled content
-        file_type = "SAMSUNG_ART" if content_type == "preinstall" else "JPEG"
-
-        file_info = {
-            "content_id": content_id,
-            "category_id": file_data.get("category_id"),
-            "file_name": file_name,
-            "file_type": file_type,
-            "file_size": file_data.get("file_size"),
-            "date": file_data.get("image_date"),
-            "thumbnail_available": True,  # Frame TV typically has thumbnails for all images
-            "matte": file_data.get("matte_id"),
-        }
-
-        # Include any additional metadata fields from the TV
-        for key, value in file_data.items():
-            if key not in file_info:
-                file_info[key] = value
-
-        return file_info
-
-    def _filter_files_by_category(self, files: list[dict], category: str | None) -> list[dict]:
-        """Filter files by category and transform them."""
-        return [
-            self._transform_file_data(file_data)
-            for file_data in files
-            if file_data.get("category_id") == category or category is None
-        ]
 
     async def _get_available_files_with_timeout(
         self, category: str | None = None, timeout_seconds: int = 10

--- a/framegallery/frame_connector/processors/sync_thread.py
+++ b/framegallery/frame_connector/processors/sync_thread.py
@@ -1,0 +1,297 @@
+"""
+The ``sync_thread`` upload processor (Docent-style).
+
+Same one-image-at-a-time behaviour as ``single_async`` (upload -> select_image ->
+delete previous), but driven through the *synchronous* ``samsungtvws`` client run in
+a background thread via ``asyncio.to_thread``. It adds the reliability plumbing that
+the Docent project uses to survive a flaky Frame:
+
+- all TV I/O is serialised behind an ``asyncio.Lock`` (the sync client is not
+  concurrency-safe);
+- the connection is proactively closed + reopened after ~30 s idle (the Frame
+  silently drops idle sockets, after which the next call hangs);
+- a Wake-on-LAN packet is sent before retrying (when ``tv_mac_address`` is set);
+- operations are retried a bounded number of times with backoff.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, Any
+
+from samsungtvws.exceptions import ResponseError
+from samsungtvws.remote import SamsungTVWS
+
+from framegallery.config import settings
+from framegallery.frame_connector.processors.base import (
+    ProcessorKind,
+    TvConnectionTimeoutError,
+    UploadProcessor,
+)
+from framegallery.logging_config import setup_logging
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from samsungtvws.art import SamsungTVArt
+
+    from framegallery.libraries.base import PhotoRef
+
+logger = setup_logging(
+    log_level=settings.log_level,
+    websocket_log_level=settings.websocket_log_level,
+    logs_path=settings.logs_path,
+)
+
+
+class SyncThreadProcessor(UploadProcessor):
+    """Push one active image at a time via the synchronous client run in a thread."""
+
+    kind = ProcessorKind.SYNC_THREAD
+
+    # Close + reopen the connection if it has been idle longer than this (seconds).
+    IDLE_RECYCLE_SECONDS = 30
+    # Socket/handshake timeout for the sync client (seconds).
+    CONNECT_TIMEOUT = 10
+    # Per-operation timeouts (seconds).
+    UPLOAD_TIMEOUT = 120
+    OP_TIMEOUT = 20
+    # Retry policy.
+    MAX_ATTEMPTS = 3
+    RETRY_DELAY = 2
+
+    def __init__(self, ip_address: str, port: int, library_manager=None) -> None:  # noqa: ANN001
+        super().__init__(ip_address, port, library_manager)
+        self._remote: SamsungTVWS | None = None
+        self._art: SamsungTVArt | None = None
+        self._op_lock = asyncio.Lock()
+        self._last_used = 0.0
+
+    # --- lifecycle ---
+
+    async def open(self) -> None:
+        """Connect the sync client (in a thread) and subscribe to slideshow updates."""
+        if not self._tv_is_online:
+            return
+        await self._connect_client()
+        self._connected = True
+        self._on_active_image_signal_connect()
+
+    async def close(self) -> None:
+        """Close the connection and (re)start the reconnection pinger."""
+        await self._close_client()
+        self._connected = False
+        self._on_active_image_signal_disconnect()
+        self._start_reconnection_pinger()
+
+    async def reconnect(self) -> None:
+        """Ensure a token, then (re)open the connection."""
+        await self._ensure_token()
+        await self.open()
+
+    # --- connection management (all blocking work off the event loop) ---
+
+    async def _connect_client(self) -> None:
+        """Build and open the synchronous client in a worker thread."""
+
+        def _build() -> tuple[SamsungTVWS, SamsungTVArt]:
+            remote = SamsungTVWS(
+                host=self._ip_address,
+                port=self._port,
+                token_file=str(self._token_file),
+                name=settings.tv_client_name,
+                timeout=self.CONNECT_TIMEOUT,
+            )
+            art = remote.art()
+            art.open()
+            return remote, art
+
+        self._remote, self._art = await asyncio.to_thread(_build)
+        self._last_used = time.monotonic()
+        logger.info("sync_thread: connected to TV at %s", self._ip_address)
+
+    async def _close_client(self) -> None:
+        """Close the synchronous client in a worker thread (idempotent)."""
+        remote = self._remote
+        self._remote = None
+        self._art = None
+        if remote is not None:
+            try:
+                await asyncio.to_thread(remote.close)
+            except Exception:
+                logger.exception("sync_thread: error closing TV client")
+
+    async def _ensure_live_client(self) -> None:
+        """Ensure a live client, recycling it if it has been idle too long."""
+        if self._art is None:
+            await self._connect_client()
+            return
+        if time.monotonic() - self._last_used > self.IDLE_RECYCLE_SECONDS:
+            logger.debug("sync_thread: recycling idle connection (idle > %ds)", self.IDLE_RECYCLE_SECONDS)
+            await self._close_client()
+            await self._connect_client()
+
+    def _wake_tv(self) -> None:
+        """Send a Wake-on-LAN packet if a TV MAC address is configured."""
+        mac = settings.tv_mac_address
+        if not mac:
+            return
+        try:
+            from wakeonlan import send_magic_packet  # noqa: PLC0415
+
+            send_magic_packet(mac)
+            logger.info("sync_thread: sent Wake-on-LAN packet to %s", mac)
+        except Exception:
+            logger.exception("sync_thread: failed to send Wake-on-LAN packet")
+
+    async def _run_tv_op(self, fn: Callable[[SamsungTVArt], Any], *, description: str, timeout: float) -> Any:  # noqa: ANN401, ASYNC109
+        """
+        Run a blocking TV operation in a thread, with recycle + bounded retries.
+
+        Only one operation runs at a time (the sync client isn't concurrency-safe).
+        A ``ResponseError`` is a definitive TV rejection and is not retried.
+        """
+        async with self._op_lock:
+            last_exc: Exception | None = None
+            for attempt in range(1, self.MAX_ATTEMPTS + 1):
+                try:
+                    await self._ensure_live_client()
+                    assert self._art is not None  # noqa: S101 -- guaranteed by _ensure_live_client
+                    result = await asyncio.wait_for(asyncio.to_thread(fn, self._art), timeout)
+                    self._last_used = time.monotonic()
+                except ResponseError:
+                    # Definitive rejection from the TV (e.g. unsupported matte); don't retry.
+                    raise
+                except Exception as exc:  # noqa: BLE001 -- retry on any transient TV/socket failure
+                    last_exc = exc
+                    logger.warning(
+                        "sync_thread: TV op '%s' failed (attempt %d/%d): %s",
+                        description,
+                        attempt,
+                        self.MAX_ATTEMPTS,
+                        exc,
+                    )
+                    await self._close_client()
+                    if attempt < self.MAX_ATTEMPTS:
+                        if attempt == 1:
+                            self._wake_tv()
+                        await asyncio.sleep(self.RETRY_DELAY * attempt)
+                else:
+                    return result
+
+            logger.error("sync_thread: TV op '%s' giving up after %d attempts", description, self.MAX_ATTEMPTS)
+            if isinstance(last_exc, TimeoutError):
+                raise TvConnectionTimeoutError from last_exc
+            if last_exc is not None:
+                raise last_exc
+            return None
+
+    # --- the hot path ---
+
+    async def apply_active_image(self, photo: PhotoRef) -> None:
+        """Upload the given photo to the TV, activate it, and delete the previous one."""
+        if not self._connected:
+            return
+
+        logger.info("sync_thread: updating active image on TV: %s", photo.composite_id)
+
+        photo_bytes = await self._fetch_photo_bytes(photo)
+        if photo_bytes is None:
+            return
+        matte = self._compute_matte(photo_bytes)
+        file_data = photo_bytes.data
+        file_type = photo_bytes.file_type_suffix
+
+        try:
+            data = await self._run_tv_op(
+                lambda art: art.upload(file_data, file_type=file_type, matte=matte, portrait_matte="none"),
+                description=f"upload {photo.composite_id}",
+                timeout=self.UPLOAD_TIMEOUT,
+            )
+        except Exception:
+            logger.exception("sync_thread: upload failed for %s", photo.composite_id)
+            return
+
+        if not data or not data.get("content_id"):
+            logger.error("sync_thread: upload completed but did not return a content_id.")
+            return
+
+        content_id = data["content_id"]
+        try:
+            await self._run_tv_op(
+                lambda art: art.select_image(content_id, "MY-C0002"),
+                description=f"select {content_id}",
+                timeout=self.OP_TIMEOUT,
+            )
+            if self._latest_content_id is not None:
+                await self._run_tv_op(
+                    lambda art: art.delete(self._latest_content_id),
+                    description=f"delete {self._latest_content_id}",
+                    timeout=self.OP_TIMEOUT,
+                )
+            self._latest_content_id = content_id
+        except Exception:
+            logger.exception("sync_thread: activate/cleanup failed for %s", content_id)
+
+    async def get_active_item_details(self) -> dict | None:
+        """Get the current active item details from the TV."""
+        if not self._connected:
+            return None
+        try:
+            return await self._run_tv_op(
+                lambda art: art.get_current(), description="get_current", timeout=self.OP_TIMEOUT
+            )
+        except Exception:
+            logger.exception("sync_thread: failed to get current active item")
+            return None
+
+    # --- generic TV file ops ---
+
+    async def list_files(self, category: str = "MY-C0002") -> list[dict] | None:
+        """List files on the TV for a category, or None if the TV is unavailable."""
+        if not self._connected:
+            logger.error("sync_thread: TV not connected, cannot list files.")
+            return None
+        try:
+            available_files = await self._run_tv_op(
+                lambda art: art.available(category), description="available", timeout=self.OP_TIMEOUT
+            )
+        except TvConnectionTimeoutError:
+            raise
+        except Exception:
+            logger.exception("sync_thread: error retrieving file list from TV")
+            return None
+
+        if not available_files:
+            return []
+        return self._filter_files_by_category(available_files, category)
+
+    async def delete_files(self, content_ids: list[str]) -> dict[str, bool] | None:
+        """Delete files from the TV in chunks, returning per-id success."""
+        if not self._connected:
+            logger.error("sync_thread: TV not connected, cannot delete files.")
+            return None
+        if not content_ids:
+            return {}
+
+        chunk_size = 20
+        result: dict[str, bool] = {}
+        try:
+            for i in range(0, len(content_ids), chunk_size):
+                chunk = content_ids[i : i + chunk_size]
+                await self._run_tv_op(
+                    lambda art, c=chunk: art.delete_list(c),
+                    description=f"delete_list ({len(chunk)})",
+                    timeout=self.OP_TIMEOUT,
+                )
+                result.update(dict.fromkeys(chunk, True))
+        except TvConnectionTimeoutError:
+            raise
+        except Exception as exc:
+            logger.exception("sync_thread: error deleting files from TV")
+            error_msg = str(exc).lower()
+            if any(term in error_msg for term in ["not found", "does not exist", "invalid"]):
+                return dict.fromkeys(content_ids, False)
+            return None
+        return result

--- a/framegallery/frame_connector/processors/sync_thread.py
+++ b/framegallery/frame_connector/processors/sync_thread.py
@@ -204,7 +204,9 @@ class SyncThreadProcessor(UploadProcessor):
         file_type = photo_bytes.file_type_suffix
 
         try:
-            data = await self._run_tv_op(
+            # NOTE: the *synchronous* SamsungTVArt.upload() returns the new content_id
+            # as a plain string (or None), unlike the async client which returns a dict.
+            content_id = await self._run_tv_op(
                 lambda art: art.upload(file_data, file_type=file_type, matte=matte, portrait_matte="none"),
                 description=f"upload {photo.composite_id}",
                 timeout=self.UPLOAD_TIMEOUT,
@@ -213,11 +215,10 @@ class SyncThreadProcessor(UploadProcessor):
             logger.exception("sync_thread: upload failed for %s", photo.composite_id)
             return
 
-        if not data or not data.get("content_id"):
-            logger.error("sync_thread: upload completed but did not return a content_id.")
+        if not content_id:
+            logger.error("sync_thread: upload of %s returned no content_id", photo.composite_id)
             return
 
-        content_id = data["content_id"]
         try:
             await self._run_tv_op(
                 lambda art: art.select_image(content_id, "MY-C0002"),

--- a/framegallery/main.py
+++ b/framegallery/main.py
@@ -29,7 +29,7 @@ from framegallery.dependencies import (
     get_library_manager,
     get_slideshow_instance,
 )
-from framegallery.frame_connector.processors import ProcessorKind, api_version, build_processor
+from framegallery.frame_connector.processors import ProcessorKind, UploadProcessor, api_version, build_processor
 from framegallery.frame_connector.status import SlideshowStatus, Status
 from framegallery.importer2.importer import Importer
 from framegallery.libraries.manager import LibraryManager
@@ -83,13 +83,38 @@ def _should_push_slideshow_tick() -> bool:
         return ConfigRepository(db).get_bool(ConfigKey.SLIDESHOW_ENABLED, default=True)
 
 
-async def update_slideshow_periodically(slideshow: Slideshow) -> None:
+async def _wait_for_processor_connection(
+    processor: UploadProcessor,
+    timeout: float = 30.0,  # noqa: ASYNC109 -- wall-clock poll budget, not a per-op timeout
+    poll_interval: float = 0.5,
+) -> bool:
+    """
+    Wait (up to ``timeout`` s) for the processor to establish its TV connection.
+
+    On startup the TV connection is established asynchronously and takes a couple of
+    seconds; without this wait the first slideshow push races the connection and is
+    dropped, leaving the display unchanged until the next interval.
+    """
+    waited = 0.0
+    while waited < timeout:
+        if processor.is_connected:
+            return True
+        await asyncio.sleep(poll_interval)
+        waited += poll_interval
+    return False
+
+
+async def update_slideshow_periodically(slideshow: Slideshow, processor: UploadProcessor) -> None:
     """
     Update the slideshow periodically.
 
     A single failing tick (e.g. an unreachable library) must never kill the loop, so any
     exception is logged and the loop continues on the next interval.
     """
+    # Let the TV connection settle before the first push so the initial image appears
+    # promptly after a restart instead of waiting a full interval.
+    if not await _wait_for_processor_connection(processor):
+        logger.info("TV not connected yet; slideshow will start pushing once it connects")
     while True:
         try:
             if _should_push_slideshow_tick():
@@ -156,7 +181,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     slideshow = Slideshow(library_manager)
     logger.info("Scheduling the slideshow updater")
-    slideshow_updater = asyncio.create_task(update_slideshow_periodically(slideshow))
+    slideshow_updater = asyncio.create_task(update_slideshow_periodically(slideshow, upload_processor))
     background_tasks.add(slideshow_updater)
     slideshow_updater.add_done_callback(background_tasks.discard)
 

--- a/framegallery/main.py
+++ b/framegallery/main.py
@@ -185,9 +185,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Shutdown: close the TV connection (whichever processor is active), cancel the
     # background loops, and close any long-lived library clients (e.g. Immich pools).
     try:
-        await upload_processor.close()
+        await upload_processor.shutdown()
     except Exception:
-        logger.exception("Error closing upload processor during shutdown")
+        logger.exception("Error shutting down upload processor")
 
     for task in list(background_tasks):
         task.cancel()

--- a/framegallery/main.py
+++ b/framegallery/main.py
@@ -29,7 +29,7 @@ from framegallery.dependencies import (
     get_library_manager,
     get_slideshow_instance,
 )
-from framegallery.frame_connector.frame_connector import FrameConnector, api_version
+from framegallery.frame_connector.processors import ProcessorKind, api_version, build_processor
 from framegallery.frame_connector.status import SlideshowStatus, Status
 from framegallery.importer2.importer import Importer
 from framegallery.libraries.manager import LibraryManager
@@ -68,6 +68,21 @@ async def run_importer_periodically(db: Session) -> None:
         await asyncio.sleep(settings.filesystem_refresh_interval)
 
 
+def _should_push_slideshow_tick() -> bool:
+    """
+    Decide whether the periodic loop should push a new active image this tick.
+
+    - In ``batch_slideshow`` mode the TV owns rotation, so the app must never push
+      per-tick (it would fight the TV's own slideshow).
+    - Otherwise honour the ``SLIDESHOW_ENABLED`` config flag. This is read from a
+      fresh session each tick so runtime enable/disable takes effect immediately.
+    """
+    if settings.upload_processor == ProcessorKind.BATCH_SLIDESHOW.value:
+        return False
+    with SessionLocal() as db:
+        return ConfigRepository(db).get_bool(ConfigKey.SLIDESHOW_ENABLED, default=True)
+
+
 async def update_slideshow_periodically(slideshow: Slideshow) -> None:
     """
     Update the slideshow periodically.
@@ -76,9 +91,12 @@ async def update_slideshow_periodically(slideshow: Slideshow) -> None:
     exception is logged and the loop continues on the next interval.
     """
     while True:
-        logger.debug("Updating slideshow")
         try:
-            await slideshow.update_slideshow()
+            if _should_push_slideshow_tick():
+                logger.debug("Updating slideshow")
+                await slideshow.update_slideshow()
+            else:
+                logger.debug("Slideshow tick skipped (disabled or TV-managed rotation)")
         except Exception:
             logger.exception("Slideshow update failed; will retry next interval")
         await asyncio.sleep(settings.slideshow_interval)
@@ -115,13 +133,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     library_manager = LibraryManager(SessionLocal)
     app.state.library_manager = library_manager
 
-    # Initialize FrameConnector within lifespan
-    frame_connector = FrameConnector(settings.tv_ip_address, settings.tv_port)
-    frame_connector.library_manager = library_manager
-    app.state.frame_connector = frame_connector  # Store in app state
+    # Build the configured upload processor within lifespan. The processor owns the
+    # TV connection and its reconnection pinger; the strategy is chosen at startup
+    # via settings.upload_processor (see framegallery/frame_connector/processors/).
+    upload_processor = build_processor(
+        ProcessorKind(settings.upload_processor),
+        settings.tv_ip_address,
+        settings.tv_port,
+        library_manager,
+    )
+    app.state.upload_processor = upload_processor  # Store in app state
 
-    # Call startup logic for the connector
-    await frame_connector.get_active_item_details()
+    # Call startup logic for the processor
+    await upload_processor.get_active_item_details()
 
     # Create a database session and run the importer periodically
     db = next(get_db())
@@ -148,7 +172,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.slideshow_signal_sse_listener = SlideshowSignalSSEListener(slideshow_event_queue)
 
     # Start TV auto-cleanup service
-    cleanup_service = TvCleanupService(frame_connector, config_repository)
+    cleanup_service = TvCleanupService(upload_processor, config_repository)
     logger.info("Scheduling the TV auto-cleanup service")
     cleanup_task = asyncio.create_task(cleanup_service.run_periodic_cleanup())
     background_tasks.add(cleanup_task)
@@ -158,7 +182,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     yield
 
-    # Shutdown: close any long-lived library clients (e.g. Immich HTTP pools).
+    # Shutdown: close the TV connection (whichever processor is active), cancel the
+    # background loops, and close any long-lived library clients (e.g. Immich pools).
+    try:
+        await upload_processor.close()
+    except Exception:
+        logger.exception("Error closing upload processor during shutdown")
+
+    for task in list(background_tasks):
+        task.cancel()
+    await asyncio.gather(*background_tasks, return_exceptions=True)
+
     await library_manager.aclose()
 
 
@@ -350,8 +384,8 @@ async def select_art(
 async def get_slideshow_status(db: Annotated[Session, Depends(get_db)]) -> SlideshowStatus:
     """Get the current slideshow status."""
     config_repo = ConfigRepository(db)
-    slideshow_status = config_repo.get_or(ConfigKey.SLIDESHOW_ENABLED, default_value=True)
-    return SlideshowStatus(enabled=slideshow_status.value == "true", interval=settings.slideshow_interval)
+    enabled = config_repo.get_bool(ConfigKey.SLIDESHOW_ENABLED, default=True)
+    return SlideshowStatus(enabled=enabled, interval=settings.slideshow_interval)
 
 
 @app.post("/api/slideshow/enable")

--- a/framegallery/repository/config_repository.py
+++ b/framegallery/repository/config_repository.py
@@ -39,6 +39,19 @@ class ConfigRepository:
 
         return value_from_db
 
+    def get_bool(self, key: ConfigKey, *, default: bool = False) -> bool:
+        """
+        Get a configuration value interpreted as a boolean.
+
+        Boolean values are stored as the JSON strings ``"true"``/``"false"`` (see
+        ``set``), but an unset key falls back to the raw ``default`` bool. This
+        helper normalises both cases so callers don't scatter ``value == "true"``.
+        """
+        value = self.get_or(key, default_value=default).value
+        if isinstance(value, str):
+            return value.strip().lower() == "true"
+        return bool(value)
+
     def set(self, key: ConfigKey, value: any) -> Config:
         """Set a configuration value by its key."""
         config = self.get_or(key)

--- a/framegallery/routers/tv_files.py
+++ b/framegallery/routers/tv_files.py
@@ -3,8 +3,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 
-from framegallery.dependencies import get_frame_connector
-from framegallery.frame_connector.frame_connector import FrameConnector, TvConnectionTimeoutError
+from framegallery.dependencies import get_upload_processor
+from framegallery.frame_connector.processors import TvConnectionTimeoutError, UploadProcessor
 from framegallery.logging_config import setup_logging
 from framegallery.schemas import TvFileResponse
 
@@ -51,7 +51,7 @@ def _raise_cleanup_failed(message: str) -> None:
 
 @router.get("/api/tv/files", status_code=status.HTTP_200_OK)
 async def list_tv_files(
-    frame_connector: Annotated[FrameConnector, Depends(get_frame_connector)],
+    frame_connector: Annotated[UploadProcessor, Depends(get_upload_processor)],
     category: str = "MY-C0002",
 ) -> list[TvFileResponse]:
     """
@@ -116,7 +116,7 @@ async def list_tv_files(
 @router.delete("/api/tv/files/{content_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_tv_file(
     content_id: str,
-    frame_connector: Annotated[FrameConnector, Depends(get_frame_connector)],
+    frame_connector: Annotated[UploadProcessor, Depends(get_upload_processor)],
 ) -> None:
     """
     Delete a file from the Samsung Frame TV.
@@ -160,7 +160,7 @@ async def delete_tv_file(
 @router.post("/api/tv/files/delete", status_code=status.HTTP_200_OK)
 async def delete_tv_files(
     request: DeleteFilesRequest,
-    frame_connector: Annotated[FrameConnector, Depends(get_frame_connector)],
+    frame_connector: Annotated[UploadProcessor, Depends(get_upload_processor)],
 ) -> DeleteFilesResponse:
     """
     Delete multiple files from the Samsung Frame TV.

--- a/framegallery/routers/tv_files.py
+++ b/framegallery/routers/tv_files.py
@@ -58,7 +58,7 @@ async def list_tv_files(
     List all files available on the Samsung Frame TV.
 
     Args:
-        frame_connector: Injected FrameConnector instance
+        frame_connector: Injected UploadProcessor instance
         category: The image folder/category on the TV (default: "MY-C0002" for user content)
 
     Returns:
@@ -71,7 +71,7 @@ async def list_tv_files(
     try:
         logger.info("Fetching TV files for category: %s", category)
 
-        # Call the FrameConnector's list_files method
+        # Call the processor's list_files method
         tv_files = await frame_connector.list_files(category=category)
 
         if tv_files is None:
@@ -123,7 +123,7 @@ async def delete_tv_file(
 
     Args:
         content_id: The content ID of the file to delete
-        frame_connector: Injected FrameConnector instance
+        frame_connector: Injected UploadProcessor instance
 
     Raises:
         HTTPException: 503 if TV is unavailable, 404 if file not found, 500 for other errors
@@ -167,7 +167,7 @@ async def delete_tv_files(
 
     Args:
         request: Request containing list of content IDs to delete
-        frame_connector: Injected FrameConnector instance
+        frame_connector: Injected UploadProcessor instance
 
     Returns:
         DeleteFilesResponse with deletion results
@@ -182,7 +182,7 @@ async def delete_tv_files(
     try:
         logger.info("Deleting %d TV files: %s", len(request.content_ids), request.content_ids)
 
-        # Call the FrameConnector's delete_files method
+        # Call the processor's delete_files method
         results = await frame_connector.delete_files(request.content_ids)
 
         if results is None:

--- a/tests/integration/framegallery/repository/test_config_repository.py
+++ b/tests/integration/framegallery/repository/test_config_repository.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session
+
+from framegallery.models import Base
+from framegallery.repository.config_repository import ConfigKey, ConfigRepository
+
+
+@pytest.fixture
+def engine() -> Engine:
+    """Create an in-memory SQLite engine for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def repository(engine: Engine) -> ConfigRepository:
+    """Return a ConfigRepository using an in-memory session."""
+    with Session(engine) as session:
+        yield ConfigRepository(session)
+        session.rollback()
+
+
+def test_get_bool_missing_returns_default(repository: ConfigRepository) -> None:
+    """An unset key falls back to the provided default bool."""
+    assert repository.get_bool(ConfigKey.SLIDESHOW_ENABLED, default=True) is True
+    assert repository.get_bool(ConfigKey.SLIDESHOW_ENABLED, default=False) is False
+
+
+def test_get_bool_reads_stored_true(repository: ConfigRepository) -> None:
+    """A bool set via set() (stored as the JSON string "true") reads back True."""
+    repository.set(ConfigKey.SLIDESHOW_ENABLED, value=True)
+    assert repository.get_bool(ConfigKey.SLIDESHOW_ENABLED, default=False) is True
+
+
+def test_get_bool_reads_stored_false(repository: ConfigRepository) -> None:
+    """A "false" string reads back False even when the default is True."""
+    repository.set(ConfigKey.SLIDESHOW_ENABLED, "false")
+    assert repository.get_bool(ConfigKey.SLIDESHOW_ENABLED, default=True) is False

--- a/tests/unit/framegallery/frame_connector/processors/test_base_lifecycle.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_base_lifecycle.py
@@ -1,0 +1,72 @@
+"""Lifecycle tests for the shared UploadProcessor machinery (pinger + shutdown)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from framegallery.frame_connector.processors.single_async import SingleAsyncProcessor
+
+_CREATE_TASK = "framegallery.frame_connector.processors.base.asyncio.create_task"
+
+
+def _build_processor() -> SingleAsyncProcessor:
+    """Build a processor without actually starting the pinger task."""
+    with patch(_CREATE_TASK):
+        return SingleAsyncProcessor("192.168.1.100", 8002)
+
+
+def test_start_pinger_is_idempotent_while_one_runs() -> None:
+    """A second _start_reconnection_pinger is a no-op while a pinger is still running."""
+    proc = _build_processor()
+    proc._pinger_task = MagicMock()  # noqa: SLF001
+    proc._pinger_task.done.return_value = False  # noqa: SLF001
+
+    with patch(_CREATE_TASK) as create_task:
+        proc._start_reconnection_pinger()  # noqa: SLF001
+        create_task.assert_not_called()
+
+
+def test_start_pinger_restarts_when_previous_finished() -> None:
+    """A finished pinger can be replaced by a new one (e.g. after a disconnect)."""
+    proc = _build_processor()
+    proc._pinger_task = MagicMock()  # noqa: SLF001
+    proc._pinger_task.done.return_value = True  # noqa: SLF001
+
+    with patch(_CREATE_TASK) as create_task:
+        proc._start_reconnection_pinger()  # noqa: SLF001
+        create_task.assert_called_once()
+
+
+def test_start_pinger_noop_while_shutting_down() -> None:
+    """No pinger is (re)started once shutdown has begun."""
+    proc = _build_processor()
+    proc._shutting_down = True  # noqa: SLF001
+
+    with patch(_CREATE_TASK) as create_task:
+        proc._start_reconnection_pinger()  # noqa: SLF001
+        create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_pinger_and_does_not_rearm() -> None:
+    """shutdown() cancels background tasks, closes, and prevents the pinger re-arming."""
+    proc = _build_processor()
+    proc._tv = AsyncMock()  # noqa: SLF001
+
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_never())
+    proc._background_tasks = {task}  # noqa: SLF001
+
+    await proc.shutdown()
+
+    assert proc._shutting_down is True  # noqa: SLF001
+    assert task.cancelled()
+    proc._tv.close.assert_awaited_once()  # noqa: SLF001
+
+    # close() runs during shutdown and calls _start_reconnection_pinger, which must no-op.
+    with patch(_CREATE_TASK) as create_task:
+        proc._start_reconnection_pinger()  # noqa: SLF001
+        create_task.assert_not_called()

--- a/tests/unit/framegallery/frame_connector/processors/test_base_lifecycle.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_base_lifecycle.py
@@ -1,6 +1,7 @@
 """Lifecycle tests for the shared UploadProcessor machinery (pinger + shutdown)."""
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -46,6 +47,45 @@ def test_start_pinger_noop_while_shutting_down() -> None:
     with patch(_CREATE_TASK) as create_task:
         proc._start_reconnection_pinger()  # noqa: SLF001
         create_task.assert_not_called()
+
+
+def _log_failure(proc: SingleAsyncProcessor, exc: Exception) -> None:
+    """Invoke the failure logger from a real exception context (so exc_info is set)."""
+    try:
+        raise exc
+    except type(exc) as caught:
+        proc._log_reconnect_failure(caught)  # noqa: SLF001
+
+
+def test_reconnect_failure_logs_traceback_once_then_warns(caplog) -> None:  # noqa: ANN001
+    """The first reconnect failure logs a traceback; identical repeats collapse to warnings."""
+    proc = _build_processor()
+
+    with caplog.at_level(logging.WARNING, logger="framegallery"):
+        _log_failure(proc, OSError("boom"))
+        _log_failure(proc, OSError("boom"))
+        _log_failure(proc, OSError("boom"))
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    # First occurrence -> one ERROR (with traceback); the two repeats -> WARNINGs.
+    assert len(errors) == 1
+    assert errors[0].exc_info is not None
+    assert errors[0].exc_info[0] is OSError
+    assert len(warnings) == 2  # noqa: PLR2004
+    assert proc._reconnect_failures == 3  # noqa: SLF001, PLR2004
+
+
+def test_reconnect_failure_new_error_logs_traceback_again(caplog) -> None:  # noqa: ANN001
+    """A different error signature resets the dedup and logs a fresh traceback."""
+    proc = _build_processor()
+
+    with caplog.at_level(logging.WARNING, logger="framegallery"):
+        _log_failure(proc, OSError("boom"))
+        _log_failure(proc, RuntimeError("different"))
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 2  # noqa: PLR2004 -- each distinct error gets its own traceback
 
 
 @pytest.mark.asyncio

--- a/tests/unit/framegallery/frame_connector/processors/test_batch_slideshow.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_batch_slideshow.py
@@ -95,10 +95,38 @@ async def test_enable_tv_rotation_sets_shuffle(processor: BatchSlideshowProcesso
     monkeypatch.setattr(batch_slideshow.settings, "batch_rotation_minutes", 5)
     processor._tv.get_auto_rotation_status = AsyncMock(return_value={"value": "5"})  # noqa: SLF001
 
-    await processor._enable_tv_rotation()  # noqa: SLF001
+    with patch.object(batch_slideshow.asyncio, "sleep", new=AsyncMock()):
+        await processor._enable_tv_rotation()  # noqa: SLF001
 
     processor._tv.set_auto_rotation_status.assert_awaited_once_with(duration=5, type=True, category=2)  # noqa: SLF001
     processor._tv.set_slideshow_status.assert_awaited_once_with(duration=5, type=True, category=2)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_enable_tv_rotation_retries_transient_failure(processor: BatchSlideshowProcessor) -> None:
+    """A transient timeout on the enable call (AssertionError) is retried, not fatal."""
+    # First attempt raises (mirrors samsungtvws' `assert data` on a timed-out request),
+    # second attempt succeeds.
+    processor._tv.set_auto_rotation_status = AsyncMock(side_effect=[AssertionError, None])  # noqa: SLF001
+    processor._tv.set_slideshow_status = AsyncMock(return_value=None)  # noqa: SLF001
+    processor._tv.get_auto_rotation_status = AsyncMock(return_value={"value": "3"})  # noqa: SLF001
+
+    with patch.object(batch_slideshow.asyncio, "sleep", new=AsyncMock()):
+        await processor._enable_tv_rotation()  # noqa: SLF001
+
+    assert processor._tv.set_auto_rotation_status.await_count == 2  # noqa: SLF001, PLR2004
+
+
+@pytest.mark.asyncio
+async def test_enable_rotation_call_gives_up_after_max_attempts(processor: BatchSlideshowProcessor) -> None:
+    """_enable_rotation_call returns False after exhausting all attempts."""
+    always_fails = AsyncMock(side_effect=AssertionError)
+
+    with patch.object(batch_slideshow.asyncio, "sleep", new=AsyncMock()):
+        ok = await processor._enable_rotation_call("set_auto_rotation_status", always_fails)  # noqa: SLF001
+
+    assert ok is False
+    assert always_fails.await_count == batch_slideshow._ROTATION_ATTEMPTS  # noqa: SLF001
 
 
 def test_cleanup_disabled_in_batch_mode(monkeypatch) -> None:  # noqa: ANN001

--- a/tests/unit/framegallery/frame_connector/processors/test_batch_slideshow.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_batch_slideshow.py
@@ -1,0 +1,113 @@
+"""Unit tests for the batch_slideshow upload processor."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from framegallery.auto_cleanup import tv_cleanup_service as cleanup_module
+from framegallery.auto_cleanup.tv_cleanup_service import TvCleanupService
+from framegallery.frame_connector.processors import batch_slideshow
+from framegallery.frame_connector.processors.batch_slideshow import BatchSlideshowProcessor
+
+EXPECTED_BATCH_SIZE = 3
+
+
+def _photo_bytes() -> SimpleNamespace:
+    return SimpleNamespace(data=b"x", file_type_suffix="jpg", width=1920, height=1080)
+
+
+@pytest.fixture
+def processor() -> BatchSlideshowProcessor:
+    """Return a connected BatchSlideshowProcessor with a mocked async TV client."""
+    with patch("framegallery.frame_connector.processors.base.asyncio.create_task"):
+        proc = BatchSlideshowProcessor("192.168.1.100", 8002)
+    proc._connected = True  # noqa: SLF001
+    proc._tv_is_online = True  # noqa: SLF001
+    proc._tv = AsyncMock()  # noqa: SLF001
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_refill_batch_evicts_then_uploads_unique(processor: BatchSlideshowProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """_refill_batch evicts existing files then uploads batch_size unique photos."""
+    monkeypatch.setattr(batch_slideshow.settings, "batch_size", EXPECTED_BATCH_SIZE)
+
+    library_manager = MagicMock()
+    # Includes a duplicate (local:2) which must be de-duplicated.
+    picks = [
+        SimpleNamespace(composite_id="local:1"),
+        SimpleNamespace(composite_id="local:2"),
+        SimpleNamespace(composite_id="local:2"),
+        SimpleNamespace(composite_id="local:3"),
+    ]
+    library_manager.pick_photo = AsyncMock(side_effect=picks)
+    processor.library_manager = library_manager
+
+    processor.list_files = AsyncMock(return_value=[{"content_id": "OLD1"}, {"content_id": "OLD2"}])
+    processor.delete_files = AsyncMock()
+    processor._fetch_photo_bytes = AsyncMock(return_value=_photo_bytes())  # noqa: SLF001
+
+    upload_count = {"n": 0}
+
+    async def fake_upload(_photo, _bytes) -> dict:  # noqa: ANN001
+        upload_count["n"] += 1
+        return {"content_id": f"NEW{upload_count['n']}"}
+
+    processor._upload_photo = fake_upload  # noqa: SLF001
+
+    await processor._refill_batch()  # noqa: SLF001
+
+    processor.delete_files.assert_awaited_once_with(["OLD1", "OLD2"])
+    assert set(processor._resident) == {"local:1", "local:2", "local:3"}  # noqa: SLF001
+    assert upload_count["n"] == EXPECTED_BATCH_SIZE
+
+
+@pytest.mark.asyncio
+async def test_apply_active_image_uploads_when_not_resident(processor: BatchSlideshowProcessor) -> None:
+    """An explicit select of a non-resident photo uploads then activates it."""
+    processor._activate_image = AsyncMock()  # noqa: SLF001
+    processor._fetch_photo_bytes = AsyncMock(return_value=_photo_bytes())  # noqa: SLF001
+    processor._upload_photo = AsyncMock(return_value={"content_id": "NEW9"})  # noqa: SLF001
+
+    await processor.apply_active_image(SimpleNamespace(composite_id="local:9"))
+
+    processor._activate_image.assert_awaited_once_with("NEW9")  # noqa: SLF001
+    assert processor._resident["local:9"] == "NEW9"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_apply_active_image_activates_resident_without_upload(processor: BatchSlideshowProcessor) -> None:
+    """An explicit select of a resident photo activates it without re-uploading."""
+    processor._activate_image = AsyncMock()  # noqa: SLF001
+    processor._upload_photo = AsyncMock()  # noqa: SLF001
+    processor._resident["local:5"] = "EXIST5"  # noqa: SLF001
+
+    await processor.apply_active_image(SimpleNamespace(composite_id="local:5"))
+
+    processor._activate_image.assert_awaited_once_with("EXIST5")  # noqa: SLF001
+    processor._upload_photo.assert_not_called()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_enable_tv_rotation_sets_shuffle(processor: BatchSlideshowProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """_enable_tv_rotation turns on the TV's shuffle rotation with the configured interval."""
+    monkeypatch.setattr(batch_slideshow.settings, "batch_rotation_minutes", 5)
+    processor._tv.get_auto_rotation_status = AsyncMock(return_value={"value": "5"})  # noqa: SLF001
+
+    await processor._enable_tv_rotation()  # noqa: SLF001
+
+    processor._tv.set_auto_rotation_status.assert_awaited_once_with(duration=5, type=True, category=2)  # noqa: SLF001
+    processor._tv.set_slideshow_status.assert_awaited_once_with(duration=5, type=True, category=2)  # noqa: SLF001
+
+
+def test_cleanup_disabled_in_batch_mode(monkeypatch) -> None:  # noqa: ANN001
+    """Auto-cleanup is force-disabled while the batch_slideshow processor is active."""
+    monkeypatch.setattr(cleanup_module.settings, "upload_processor", "batch_slideshow")
+    config_repo = MagicMock()
+    config_repo.get_bool.return_value = True  # even if the flag says enabled...
+
+    service = TvCleanupService(MagicMock(), config_repo)
+
+    assert service._is_cleanup_enabled() is False  # noqa: SLF001
+    config_repo.get_bool.assert_not_called()  # batch short-circuits before reading config

--- a/tests/unit/framegallery/frame_connector/processors/test_factory.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_factory.py
@@ -1,0 +1,52 @@
+"""Tests for the upload-processor factory."""
+
+from unittest.mock import patch
+
+import pytest
+
+from framegallery.frame_connector.processors import ProcessorKind, build_processor
+from framegallery.frame_connector.processors.batch_slideshow import BatchSlideshowProcessor
+from framegallery.frame_connector.processors.single_async import SingleAsyncProcessor
+from framegallery.frame_connector.processors.sync_thread import SyncThreadProcessor
+
+
+def test_build_single_async_processor() -> None:
+    """The factory builds a SingleAsyncProcessor for the single_async kind."""
+    with patch("framegallery.frame_connector.processors.base.asyncio.create_task"):
+        processor = build_processor(ProcessorKind.SINGLE_ASYNC, "192.168.1.100", 8002)
+
+    assert isinstance(processor, SingleAsyncProcessor)
+    assert processor.kind == ProcessorKind.SINGLE_ASYNC
+
+
+def test_build_sync_thread_processor() -> None:
+    """The factory builds a SyncThreadProcessor for the sync_thread kind."""
+    with patch("framegallery.frame_connector.processors.base.asyncio.create_task"):
+        processor = build_processor(ProcessorKind.SYNC_THREAD, "192.168.1.100", 8002)
+
+    assert isinstance(processor, SyncThreadProcessor)
+    assert processor.kind == ProcessorKind.SYNC_THREAD
+
+
+def test_build_batch_slideshow_processor() -> None:
+    """The factory builds a BatchSlideshowProcessor for the batch_slideshow kind."""
+    with patch("framegallery.frame_connector.processors.base.asyncio.create_task"):
+        processor = build_processor(ProcessorKind.BATCH_SLIDESHOW, "192.168.1.100", 8002)
+
+    assert isinstance(processor, BatchSlideshowProcessor)
+    assert processor.kind == ProcessorKind.BATCH_SLIDESHOW
+
+
+def test_build_processor_passes_library_manager() -> None:
+    """The factory forwards the library_manager to the processor."""
+    sentinel = object()
+    with patch("framegallery.frame_connector.processors.base.asyncio.create_task"):
+        processor = build_processor(ProcessorKind.SINGLE_ASYNC, "192.168.1.100", 8002, sentinel)
+
+    assert processor.library_manager is sentinel
+
+
+def test_build_processor_unknown_kind_raises() -> None:
+    """An unrecognised kind raises ValueError rather than returning None."""
+    with pytest.raises(ValueError, match="Unknown upload processor"):
+        build_processor("bogus", "192.168.1.100", 8002)  # type: ignore[arg-type]

--- a/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
@@ -151,8 +151,9 @@ async def test_apply_active_image_uploads_activates_deletes(processor: SyncThrea
 
     async def fake_run(fn, *, description, timeout):  # noqa: ANN001, ANN202, ARG001, ASYNC109
         calls.append(description)
+        # The sync SamsungTVArt.upload() returns the content_id as a bare string.
         if description.startswith("upload"):
-            return {"content_id": "MY-F0009"}
+            return "MY-F0009"
         return None
 
     processor._run_tv_op = fake_run  # noqa: SLF001

--- a/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
@@ -1,0 +1,176 @@
+"""Unit tests for the sync_thread upload processor."""
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from framegallery.frame_connector.processors import sync_thread
+from framegallery.frame_connector.processors.sync_thread import SyncThreadProcessor
+
+
+@pytest.fixture
+def processor() -> SyncThreadProcessor:
+    """Return a connected SyncThreadProcessor with a mocked sync art client."""
+    with patch("framegallery.frame_connector.processors.base.asyncio.create_task"):
+        proc = SyncThreadProcessor("192.168.1.100", 8002)
+    proc._connected = True  # noqa: SLF001
+    proc._tv_is_online = True  # noqa: SLF001
+    proc._art = MagicMock()  # noqa: SLF001
+    proc._last_used = time.monotonic()  # noqa: SLF001
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_run_tv_op_runs_in_thread(processor: SyncThreadProcessor) -> None:
+    """A TV op is dispatched via asyncio.to_thread and its result returned."""
+    processor._art.get_current.return_value = {"content_id": "MY-F0001"}  # noqa: SLF001
+
+    with patch(
+        "framegallery.frame_connector.processors.sync_thread.asyncio.to_thread",
+        wraps=asyncio.to_thread,
+    ) as to_thread:
+        result = await processor._run_tv_op(  # noqa: SLF001
+            lambda art: art.get_current(), description="get_current", timeout=5
+        )
+
+    assert result == {"content_id": "MY-F0001"}
+    to_thread.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_run_tv_op_serialises_with_lock(processor: SyncThreadProcessor) -> None:
+    """The op lock is held for the duration of an operation."""
+    processor._ensure_live_client = AsyncMock()  # noqa: SLF001
+
+    async def op() -> str:
+        return await processor._run_tv_op(lambda art: "ok", description="x", timeout=5)  # noqa: SLF001, ARG005
+
+    # If the lock were not held, acquiring it here would not matter; this asserts the
+    # public contract that operations acquire _op_lock.
+    assert not processor._op_lock.locked()  # noqa: SLF001
+    await op()
+    assert not processor._op_lock.locked()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_run_tv_op_retries_then_succeeds(processor: SyncThreadProcessor) -> None:
+    """A transient failure is retried (with WoL + close) and then succeeds."""
+    processor._ensure_live_client = AsyncMock()  # noqa: SLF001
+    processor._close_client = AsyncMock()  # noqa: SLF001
+    processor._wake_tv = MagicMock()  # noqa: SLF001
+
+    seq: list[object] = [OSError("boom"), "ok"]
+
+    def fn(_art: object) -> object:
+        item = seq.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    with patch("framegallery.frame_connector.processors.sync_thread.asyncio.sleep", new=AsyncMock()):
+        result = await processor._run_tv_op(fn, description="x", timeout=5)  # noqa: SLF001
+
+    assert result == "ok"
+    processor._close_client.assert_awaited()  # noqa: SLF001
+    processor._wake_tv.assert_called_once()  # WoL on the first retry  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_run_tv_op_gives_up_after_max_attempts(processor: SyncThreadProcessor) -> None:
+    """After MAX_ATTEMPTS failures the last exception is raised."""
+    processor._ensure_live_client = AsyncMock()  # noqa: SLF001
+    processor._close_client = AsyncMock()  # noqa: SLF001
+    processor._wake_tv = MagicMock()  # noqa: SLF001
+
+    def fn(_art: object) -> object:
+        raise OSError("always")
+
+    with (
+        patch("framegallery.frame_connector.processors.sync_thread.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(OSError, match="always"),
+    ):
+        await processor._run_tv_op(fn, description="x", timeout=5)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_ensure_live_client_recycles_when_idle(processor: SyncThreadProcessor) -> None:
+    """An idle connection is closed and reopened before the next op."""
+    processor._last_used = time.monotonic() - (SyncThreadProcessor.IDLE_RECYCLE_SECONDS + 5)  # noqa: SLF001
+    processor._close_client = AsyncMock()  # noqa: SLF001
+    processor._connect_client = AsyncMock()  # noqa: SLF001
+
+    await processor._ensure_live_client()  # noqa: SLF001
+
+    processor._close_client.assert_awaited_once()  # noqa: SLF001
+    processor._connect_client.assert_awaited_once()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_ensure_live_client_reuses_when_fresh(processor: SyncThreadProcessor) -> None:
+    """A recently-used connection is reused without recycling."""
+    processor._last_used = time.monotonic()  # noqa: SLF001
+    processor._close_client = AsyncMock()  # noqa: SLF001
+    processor._connect_client = AsyncMock()  # noqa: SLF001
+
+    await processor._ensure_live_client()  # noqa: SLF001
+
+    processor._close_client.assert_not_called()  # noqa: SLF001
+    processor._connect_client.assert_not_called()  # noqa: SLF001
+
+
+def test_wake_tv_noop_without_mac(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """No Wake-on-LAN packet is sent when no MAC is configured."""
+    monkeypatch.setattr(sync_thread.settings, "tv_mac_address", None)
+    send = MagicMock()
+    with patch.dict("sys.modules", {"wakeonlan": SimpleNamespace(send_magic_packet=send)}):
+        processor._wake_tv()  # noqa: SLF001 -- should simply do nothing
+    send.assert_not_called()
+
+
+def test_wake_tv_sends_packet_with_mac(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """A Wake-on-LAN packet is sent when a MAC is configured."""
+    monkeypatch.setattr(sync_thread.settings, "tv_mac_address", "AA:BB:CC:DD:EE:FF")
+    send = MagicMock()
+    with patch.dict("sys.modules", {"wakeonlan": SimpleNamespace(send_magic_packet=send)}):
+        processor._wake_tv()  # noqa: SLF001
+    send.assert_called_once_with("AA:BB:CC:DD:EE:FF")
+
+
+@pytest.mark.asyncio
+async def test_apply_active_image_uploads_activates_deletes(processor: SyncThreadProcessor) -> None:
+    """apply_active_image uploads, activates, and deletes the previous image."""
+    photo = SimpleNamespace(composite_id="local:1")
+    photo_bytes = SimpleNamespace(data=b"x", file_type_suffix="jpg", width=1920, height=1080)
+    processor._fetch_photo_bytes = AsyncMock(return_value=photo_bytes)  # noqa: SLF001
+    processor._latest_content_id = "MY-OLD"  # noqa: SLF001
+
+    calls: list[str] = []
+
+    async def fake_run(fn, *, description, timeout):  # noqa: ANN001, ANN202, ARG001, ASYNC109
+        calls.append(description)
+        if description.startswith("upload"):
+            return {"content_id": "MY-F0009"}
+        return None
+
+    processor._run_tv_op = fake_run  # noqa: SLF001
+
+    await processor.apply_active_image(photo)
+
+    assert any(d.startswith("upload") for d in calls)
+    assert any(d.startswith("select MY-F0009") for d in calls)
+    assert any(d.startswith("delete MY-OLD") for d in calls)
+    assert processor._latest_content_id == "MY-F0009"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_apply_active_image_skips_when_not_connected(processor: SyncThreadProcessor) -> None:
+    """Nothing is uploaded when the processor is not connected."""
+    processor._connected = False  # noqa: SLF001
+    processor._fetch_photo_bytes = AsyncMock()  # noqa: SLF001
+
+    await processor.apply_active_image(SimpleNamespace(composite_id="local:1"))
+
+    processor._fetch_photo_bytes.assert_not_called()  # noqa: SLF001

--- a/tests/unit/framegallery/frame_connector/test_frame_connector.py
+++ b/tests/unit/framegallery/frame_connector/test_frame_connector.py
@@ -1,14 +1,12 @@
-"""Unit tests for FrameConnector.list_files() method."""
+"""Unit tests for SingleAsyncProcessor.list_files() method."""
 
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import websockets.exceptions
 
-from framegallery.frame_connector.frame_connector import (
-    FrameConnector,
-    TvConnectionTimeoutError,
-)
+from framegallery.frame_connector.processors.base import TvConnectionTimeoutError
+from framegallery.frame_connector.processors.single_async import SingleAsyncProcessor
 
 # Constants for test expectations
 EXPECTED_MY_C0002_FILES = 2  # Expected number of files in MY-C0002 category
@@ -16,10 +14,10 @@ EXPECTED_ALL_FILES = 2  # Expected number of files when no category filter is ap
 
 
 @pytest.fixture
-def frame_connector() -> FrameConnector:
-    """Create a FrameConnector instance for testing."""
-    with patch("framegallery.frame_connector.frame_connector.asyncio.create_task"):
-        connector = FrameConnector("192.168.1.100", 8001)
+def frame_connector() -> SingleAsyncProcessor:
+    """Create a SingleAsyncProcessor instance for testing."""
+    with patch("framegallery.frame_connector.processors.base.asyncio.create_task"):
+        connector = SingleAsyncProcessor("192.168.1.100", 8001)
         connector._tv = AsyncMock()  # noqa: SLF001
         connector._connected = True  # noqa: SLF001
         connector._tv_is_online = True  # noqa: SLF001
@@ -27,7 +25,7 @@ def frame_connector() -> FrameConnector:
 
 
 @pytest.mark.asyncio
-async def test_list_files_success(frame_connector: FrameConnector) -> None:
+async def test_list_files_success(frame_connector: SingleAsyncProcessor) -> None:
     """Test successful retrieval of files from TV."""
     mock_tv_response = [
         {
@@ -79,7 +77,7 @@ async def test_list_files_success(frame_connector: FrameConnector) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_files_with_specific_category(frame_connector: FrameConnector) -> None:
+async def test_list_files_with_specific_category(frame_connector: SingleAsyncProcessor) -> None:
     """Test retrieval of files for a specific category."""
     mock_tv_response = [
         {
@@ -108,7 +106,7 @@ async def test_list_files_with_specific_category(frame_connector: FrameConnector
 
 
 @pytest.mark.asyncio
-async def test_list_files_no_category_filter(frame_connector: FrameConnector) -> None:
+async def test_list_files_no_category_filter(frame_connector: SingleAsyncProcessor) -> None:
     """Test retrieval of all files when category is None."""
     mock_tv_response = [
         {
@@ -132,7 +130,7 @@ async def test_list_files_no_category_filter(frame_connector: FrameConnector) ->
 
 
 @pytest.mark.asyncio
-async def test_list_files_tv_not_connected(frame_connector: FrameConnector) -> None:
+async def test_list_files_tv_not_connected(frame_connector: SingleAsyncProcessor) -> None:
     """Test behavior when TV is not connected."""
     frame_connector._connected = False  # noqa: SLF001
 
@@ -143,7 +141,7 @@ async def test_list_files_tv_not_connected(frame_connector: FrameConnector) -> N
 
 
 @pytest.mark.asyncio
-async def test_list_files_tv_offline(frame_connector: FrameConnector) -> None:
+async def test_list_files_tv_offline(frame_connector: SingleAsyncProcessor) -> None:
     """Test behavior when TV is offline."""
     frame_connector._tv_is_online = False  # noqa: SLF001
 
@@ -154,7 +152,7 @@ async def test_list_files_tv_offline(frame_connector: FrameConnector) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_files_empty_response(frame_connector: FrameConnector) -> None:
+async def test_list_files_empty_response(frame_connector: SingleAsyncProcessor) -> None:
     """Test handling of empty response from TV."""
     frame_connector._get_available_files_with_timeout = AsyncMock(return_value=[])  # noqa: SLF001
 
@@ -164,7 +162,7 @@ async def test_list_files_empty_response(frame_connector: FrameConnector) -> Non
 
 
 @pytest.mark.asyncio
-async def test_list_files_none_response(frame_connector: FrameConnector) -> None:
+async def test_list_files_none_response(frame_connector: SingleAsyncProcessor) -> None:
     """Test handling of None response from TV."""
     frame_connector._get_available_files_with_timeout = AsyncMock(return_value=None)  # noqa: SLF001
 
@@ -174,7 +172,7 @@ async def test_list_files_none_response(frame_connector: FrameConnector) -> None
 
 
 @pytest.mark.asyncio
-async def test_list_files_connection_closed_error(frame_connector: FrameConnector) -> None:
+async def test_list_files_connection_closed_error(frame_connector: SingleAsyncProcessor) -> None:
     """Test handling of connection closed error."""
     frame_connector._get_available_files_with_timeout = AsyncMock(  # noqa: SLF001
         side_effect=websockets.exceptions.ConnectionClosedError(None, None)
@@ -188,7 +186,7 @@ async def test_list_files_connection_closed_error(frame_connector: FrameConnecto
 
 
 @pytest.mark.asyncio
-async def test_list_files_timeout_error(frame_connector: FrameConnector) -> None:
+async def test_list_files_timeout_error(frame_connector: SingleAsyncProcessor) -> None:
     """Test handling of timeout error."""
     frame_connector._get_available_files_with_timeout = AsyncMock(side_effect=TimeoutError())  # noqa: SLF001
 
@@ -197,7 +195,7 @@ async def test_list_files_timeout_error(frame_connector: FrameConnector) -> None
 
 
 @pytest.mark.asyncio
-async def test_list_files_generic_exception(frame_connector: FrameConnector) -> None:
+async def test_list_files_generic_exception(frame_connector: SingleAsyncProcessor) -> None:
     """Test handling of generic exceptions."""
     frame_connector._get_available_files_with_timeout = AsyncMock(side_effect=Exception("Unknown error"))  # noqa: SLF001
 
@@ -207,7 +205,7 @@ async def test_list_files_generic_exception(frame_connector: FrameConnector) -> 
 
 
 @pytest.mark.asyncio
-async def test_list_files_field_mapping(frame_connector: FrameConnector) -> None:
+async def test_list_files_field_mapping(frame_connector: SingleAsyncProcessor) -> None:
     """Test that fields are properly mapped from different possible names."""
     mock_tv_response = [
         {

--- a/tests/unit/framegallery/routers/test_tv_files_router.py
+++ b/tests/unit/framegallery/routers/test_tv_files_router.py
@@ -5,8 +5,8 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from framegallery.dependencies import get_frame_connector
-from framegallery.frame_connector.frame_connector import FrameConnector, TvConnectionTimeoutError
+from framegallery.dependencies import get_upload_processor
+from framegallery.frame_connector.processors import TvConnectionTimeoutError, UploadProcessor
 from framegallery.main import app
 
 # Test constants
@@ -22,28 +22,28 @@ def client() -> TestClient:
 
 
 @pytest.fixture
-def mock_frame_connector() -> FrameConnector:
-    """Create a mock FrameConnector."""
-    mock_connector = MagicMock(spec=FrameConnector)
+def mock_frame_connector() -> UploadProcessor:
+    """Create a mock UploadProcessor."""
+    mock_connector = MagicMock(spec=UploadProcessor)
     mock_connector.list_files = AsyncMock()
     return mock_connector
 
 
 @pytest.fixture(autouse=True)
-def override_get_frame_connector(mock_frame_connector: FrameConnector) -> Generator[None, None, None]:
-    """Replace the actual get_frame_connector with one that returns our mock."""
+def override_get_upload_processor(mock_frame_connector: UploadProcessor) -> Generator[None, None, None]:
+    """Replace the actual get_upload_processor with one that returns our mock."""
 
-    def _override_get_frame_connector() -> FrameConnector:
+    def _override_get_upload_processor() -> UploadProcessor:
         return mock_frame_connector
 
-    app.dependency_overrides[get_frame_connector] = _override_get_frame_connector
+    app.dependency_overrides[get_upload_processor] = _override_get_upload_processor
     yield  # Allow tests to run
     # Clean up the override after tests
-    app.dependency_overrides.pop(get_frame_connector, None)
+    app.dependency_overrides.pop(get_upload_processor, None)
 
 
 @pytest.mark.asyncio
-async def test_list_tv_files_success(client: TestClient, mock_frame_connector: FrameConnector) -> None:
+async def test_list_tv_files_success(client: TestClient, mock_frame_connector: UploadProcessor) -> None:
     """Test successfully listing TV files."""
     # Mock TV response data
     mock_tv_files = [
@@ -102,7 +102,7 @@ async def test_list_tv_files_success(client: TestClient, mock_frame_connector: F
 
 
 @pytest.mark.asyncio
-async def test_list_tv_files_with_custom_category(client: TestClient, mock_frame_connector: FrameConnector) -> None:
+async def test_list_tv_files_with_custom_category(client: TestClient, mock_frame_connector: UploadProcessor) -> None:
     """Test listing TV files with a custom category."""
     mock_tv_files = [
         {
@@ -129,7 +129,7 @@ async def test_list_tv_files_with_custom_category(client: TestClient, mock_frame
 
 
 @pytest.mark.asyncio
-async def test_list_tv_files_empty_result(client: TestClient, mock_frame_connector: FrameConnector) -> None:
+async def test_list_tv_files_empty_result(client: TestClient, mock_frame_connector: UploadProcessor) -> None:
     """Test listing TV files when no files are available."""
     mock_frame_connector.list_files.return_value = []
 
@@ -145,7 +145,7 @@ async def test_list_tv_files_empty_result(client: TestClient, mock_frame_connect
 
 
 @pytest.mark.asyncio
-async def test_list_tv_files_tv_unavailable(client: TestClient, mock_frame_connector: FrameConnector) -> None:
+async def test_list_tv_files_tv_unavailable(client: TestClient, mock_frame_connector: UploadProcessor) -> None:
     """Test listing TV files when TV is unavailable."""
     # When TV is unavailable, list_files returns None
     mock_frame_connector.list_files.return_value = None
@@ -161,7 +161,7 @@ async def test_list_tv_files_tv_unavailable(client: TestClient, mock_frame_conne
 
 
 @pytest.mark.asyncio
-async def test_list_tv_files_timeout_error(client: TestClient, mock_frame_connector: FrameConnector) -> None:
+async def test_list_tv_files_timeout_error(client: TestClient, mock_frame_connector: UploadProcessor) -> None:
     """Test listing TV files when TV connection times out."""
     mock_frame_connector.list_files.side_effect = TvConnectionTimeoutError("Timeout")
 
@@ -176,7 +176,7 @@ async def test_list_tv_files_timeout_error(client: TestClient, mock_frame_connec
 
 
 @pytest.mark.asyncio
-async def test_list_tv_files_unexpected_error(client: TestClient, mock_frame_connector: FrameConnector) -> None:
+async def test_list_tv_files_unexpected_error(client: TestClient, mock_frame_connector: UploadProcessor) -> None:
     """Test listing TV files when an unexpected error occurs."""
     mock_frame_connector.list_files.side_effect = Exception("Unexpected error")
 
@@ -191,7 +191,7 @@ async def test_list_tv_files_unexpected_error(client: TestClient, mock_frame_con
 
 
 @pytest.mark.asyncio
-async def test_list_tv_files_missing_fields(client: TestClient, mock_frame_connector: FrameConnector) -> None:
+async def test_list_tv_files_missing_fields(client: TestClient, mock_frame_connector: UploadProcessor) -> None:
     """Test listing TV files with missing optional fields."""
     # Mock response with minimal required fields and some missing optional fields
     mock_tv_files = [
@@ -229,7 +229,7 @@ async def test_list_tv_files_missing_fields(client: TestClient, mock_frame_conne
 
 
 @pytest.mark.asyncio
-async def test_list_tv_files_field_mapping(client: TestClient, mock_frame_connector: FrameConnector) -> None:
+async def test_list_tv_files_field_mapping(client: TestClient, mock_frame_connector: UploadProcessor) -> None:
     """Test that fields are properly mapped from TV response to API response."""
     mock_tv_files = [
         {

--- a/tests/unit/framegallery/test_slideshow_gating.py
+++ b/tests/unit/framegallery/test_slideshow_gating.py
@@ -1,0 +1,45 @@
+"""Tests for the periodic slideshow-tick gating (GAP 1: SLIDESHOW_ENABLED)."""
+
+from unittest.mock import MagicMock, patch
+
+from framegallery import main
+from framegallery.repository.config_repository import ConfigKey
+
+
+def test_batch_mode_never_pushes(monkeypatch) -> None:  # noqa: ANN001
+    """In batch_slideshow mode the app must not push per-tick (the TV rotates)."""
+    monkeypatch.setattr(main.settings, "upload_processor", "batch_slideshow")
+
+    # Config is never consulted in batch mode.
+    with patch.object(main, "SessionLocal") as session_local:
+        assert main._should_push_slideshow_tick() is False  # noqa: SLF001
+        session_local.assert_not_called()
+
+
+def test_single_async_honours_enabled_flag(monkeypatch) -> None:  # noqa: ANN001
+    """In single_async mode the tick follows the SLIDESHOW_ENABLED config flag."""
+    monkeypatch.setattr(main.settings, "upload_processor", "single_async")
+
+    fake_repo = MagicMock()
+    fake_repo.get_bool.return_value = True
+
+    with (
+        patch.object(main, "SessionLocal"),
+        patch.object(main, "ConfigRepository", return_value=fake_repo),
+    ):
+        assert main._should_push_slideshow_tick() is True  # noqa: SLF001
+        fake_repo.get_bool.assert_called_once_with(ConfigKey.SLIDESHOW_ENABLED, default=True)
+
+
+def test_single_async_disabled_skips(monkeypatch) -> None:  # noqa: ANN001
+    """When SLIDESHOW_ENABLED is false, the tick is skipped."""
+    monkeypatch.setattr(main.settings, "upload_processor", "single_async")
+
+    fake_repo = MagicMock()
+    fake_repo.get_bool.return_value = False
+
+    with (
+        patch.object(main, "SessionLocal"),
+        patch.object(main, "ConfigRepository", return_value=fake_repo),
+    ):
+        assert main._should_push_slideshow_tick() is False  # noqa: SLF001

--- a/tests/unit/framegallery/test_slideshow_gating.py
+++ b/tests/unit/framegallery/test_slideshow_gating.py
@@ -1,6 +1,8 @@
 """Tests for the periodic slideshow-tick gating (GAP 1: SLIDESHOW_ENABLED)."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from framegallery import main
 from framegallery.repository.config_repository import ConfigKey
@@ -43,3 +45,24 @@ def test_single_async_disabled_skips(monkeypatch) -> None:  # noqa: ANN001
         patch.object(main, "ConfigRepository", return_value=fake_repo),
     ):
         assert main._should_push_slideshow_tick() is False  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_wait_for_processor_returns_true_when_connected() -> None:
+    """The startup wait returns immediately once the processor is connected."""
+    processor = MagicMock()
+    processor.is_connected = True
+
+    assert await main._wait_for_processor_connection(processor, timeout=5) is True  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_wait_for_processor_times_out_when_never_connected() -> None:
+    """The startup wait gives up after the timeout if the TV never connects."""
+    processor = MagicMock()
+    processor.is_connected = False
+
+    with patch.object(main.asyncio, "sleep", new=AsyncMock()):
+        result = await main._wait_for_processor_connection(processor, timeout=1.0, poll_interval=0.5)  # noqa: SLF001
+
+    assert result is False


### PR DESCRIPTION
## Why

The Samsung Frame TV intermittently **crashes in Art Mode during image upload / photo changes**, and the root cause hasn't been isolated. This makes the upload mechanism **selectable at startup** so we can A/B test which strategy the TV tolerates, thereby localizing the fault (upload/delete churn? the persistent async socket? the activation step?).

Selection is via the `upload_processor` setting (env `UPLOAD_PROCESSOR`; restart to apply).

## The three processors

| `upload_processor` | Behaviour |
|---|---|
| `single_async` (default) | The **original behaviour**, refactored behind a new `UploadProcessor` interface: async WebSocket, one image at a time (upload → `select_image` → delete previous). |
| `sync_thread` | Same one-at-a-time behaviour via the **synchronous** `samsungtvws` client run in a thread, with idle-connection recycling (~30s), Wake-on-LAN before retry, and bounded retries with backoff (Docent-style). |
| `batch_slideshow` | Upload a batch (`batch_size`) once and hand rotation to the **TV's own slideshow**; the app-driven push loop and auto-cleanup are suppressed in this mode. |

## What's in here

- New package `framegallery/frame_connector/processors/` — the `UploadProcessor` ABC + shared connection machinery (ICMP pinger, token pairing, byte-fetch, matte, signal wiring), the three strategies, and a factory. The old `FrameConnector` is removed; `app.state` and the tv_files router / cleanup service now use the interface.
- **Two latent bugs fixed along the way:**
  - The slideshow loop ignored `SLIDESHOW_ENABLED` (and the enabled-by-default case compared a bool to the string `"true"`). Added `ConfigRepository.get_bool` and a tick guard that also suppresses per-tick pushes in `batch_slideshow` mode.
  - No shutdown hook — the lifespan now closes the active processor and cancels background tasks.
- New settings: `upload_processor`, `tv_mac_address`, `batch_size`, `batch_rotation_minutes` (documented in `README.md` and `.env.dist`).
- Unit tests for the factory, `get_bool`, slideshow gating, and the `sync_thread` / `batch_slideshow` strategies.

## Testing

- `ruff check` clean; `164 passed` under pytest; pre-commit hook (ruff + format + pytest) passed on commit.
- App boots under each `UPLOAD_PROCESSOR` value (build smoke test).
- **Not covered:** end-to-end against a real Frame TV (no hardware access here) — that's the actual diagnostic loop for the reporter to run.

## Follow-up docs

Companion commit adds `docs/alternative-systems/` comparisons (frame-sync, Docent) that informed this design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)