### PR TITLE
fix: add settle delay between TV commands to prevent Art Mode crashes

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -17,6 +17,12 @@ upload_processor=single_async
 # TV MAC address, used by the "sync_thread" processor to Wake-on-LAN before a
 # retry. Optional; find it with `arp -n <tv-ip>`.
 # tv_mac_address=AA:BB:CC:DD:EE:FF
+# Settle delay (seconds) between consecutive TV commands in the single-image
+# processors (single_async / sync_thread): after upload before switching to the
+# new image, and before deleting the previous one. The Frame needs a moment to
+# digest an upload before it reliably accepts the next command; issuing them
+# back-to-back can crash Art Mode back to regular TV. Set to 0 to disable.
+tv_command_delay=5.0
 # "batch_slideshow" processor tuning: how many images to upload in one batch and
 # the TV's own rotation interval in whole minutes.
 batch_size=50

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ filesystem_refresh_interval=600
 # Useful for A/B testing which mechanism your TV tolerates without crashing. See
 # the "Upload processors" section below.
 upload_processor=single_async
+# Settle delay (seconds) between consecutive TV commands in the single-image
+# processors (single_async/sync_thread). Guards against Art Mode crashing when the
+# switch command is sent before the TV has finished digesting the upload. 0 disables.
+tv_command_delay=5.0
 
 # Docker Volume Mount Paths (customize for your setup)
 IMAGES_PATH=./images
@@ -205,6 +209,7 @@ Related settings:
 | Variable | Default | Applies to | Description |
 |---|---|---|---|
 | `tv_mac_address` | *(unset)* | `sync_thread` | TV MAC address; when set, a Wake-on-LAN packet is sent before retrying a failed connection (`arp -n <tv-ip>` to find it). |
+| `tv_command_delay` | `5.0` | `single_async`, `sync_thread` | Settle delay in seconds inserted between consecutive TV commands: after `upload` before `select_image`, and before deleting the previous image. The Frame needs a moment to finish digesting an upload before it reliably accepts the next command; issuing them back-to-back can crash Art Mode back to regular TV. Set to `0` for the original back-to-back behaviour. |
 | `batch_size` | `50` | `batch_slideshow` | How many images to upload to the TV in one batch. |
 | `batch_rotation_minutes` | `3` | `batch_slideshow` | The TV's own rotation interval, in whole minutes (the TV API only accepts minutes, so `slideshow_interval` does not apply in this mode). |
 

--- a/framegallery/config.py
+++ b/framegallery/config.py
@@ -38,6 +38,13 @@ class Settings(BaseSettings):
     # packet before retrying a failed connection. Optional; find it with
     # `arp -n <tv-ip>`. Only helps when the TV is asleep, not for art-mode crashes.
     tv_mac_address: str | None = None
+    # Settle delay (seconds) inserted between consecutive TV commands in the
+    # single-image processors (single_async / sync_thread): after upload before
+    # select_image, and before deleting the previous image. The Frame needs a moment
+    # to finish digesting an upload before it reliably accepts the follow-up command;
+    # issuing them back-to-back can crash Art Mode back to regular TV. Set to 0 to
+    # disable (original back-to-back behaviour).
+    tv_command_delay: float = 5.0
     # "batch_slideshow" processor: how many images to upload to the TV in one batch,
     # and the TV's own rotation interval in whole minutes (the TV API only accepts
     # minutes, so the 180s slideshow_interval doesn't apply in this mode).

--- a/framegallery/frame_connector/processors/base.py
+++ b/framegallery/frame_connector/processors/base.py
@@ -294,6 +294,18 @@ class UploadProcessor(abc.ABC):
             if file_data.get("category_id") == category or category is None
         ]
 
+    async def _settle(self) -> None:
+        """
+        Pause briefly between consecutive TV commands.
+
+        The Frame needs a moment to finish digesting an upload before it will
+        reliably accept the follow-up ``select_image``/``delete``; issuing them
+        back-to-back can crash Art Mode back to regular TV. Controlled by
+        ``settings.tv_command_delay`` (seconds); a value of 0 disables the pause.
+        """
+        if settings.tv_command_delay > 0:
+            await asyncio.sleep(settings.tv_command_delay)
+
     def _compute_matte(self, photo_bytes: PhotoBytes) -> str:
         """
         Pick the matte from the final (post-crop) dimensions.

--- a/framegallery/frame_connector/processors/single_async.py
+++ b/framegallery/frame_connector/processors/single_async.py
@@ -148,11 +148,14 @@ class SingleAsyncProcessor(UploadProcessor):
             await self.close()
             return
 
-        # Make uploaded image active
+        # Make uploaded image active. Give the TV a moment to finish processing the
+        # upload before switching to it: activating too soon can crash Art Mode.
         if data and data.get("content_id"):
+            await self._settle()
             await self._activate_image(data["content_id"])
             # Delete previously active image
             if self._latest_content_id is not None:
+                await self._settle()
                 await self._delete_image(self._latest_content_id)
             self._latest_content_id = data["content_id"]
         elif data:

--- a/framegallery/frame_connector/processors/sync_thread.py
+++ b/framegallery/frame_connector/processors/sync_thread.py
@@ -220,12 +220,16 @@ class SyncThreadProcessor(UploadProcessor):
             return
 
         try:
+            # Give the TV a moment to finish processing the upload before switching
+            # to it: activating too soon can crash Art Mode back to regular TV.
+            await self._settle()
             await self._run_tv_op(
                 lambda art: art.select_image(content_id, "MY-C0002"),
                 description=f"select {content_id}",
                 timeout=self.OP_TIMEOUT,
             )
             if self._latest_content_id is not None:
+                await self._settle()
                 await self._run_tv_op(
                     lambda art: art.delete(self._latest_content_id),
                     description=f"delete {self._latest_content_id}",

--- a/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
@@ -145,6 +145,7 @@ async def test_apply_active_image_uploads_activates_deletes(processor: SyncThrea
     photo = SimpleNamespace(composite_id="local:1")
     photo_bytes = SimpleNamespace(data=b"x", file_type_suffix="jpg", width=1920, height=1080)
     processor._fetch_photo_bytes = AsyncMock(return_value=photo_bytes)  # noqa: SLF001
+    processor._settle = AsyncMock()  # noqa: SLF001 -- don't actually sleep in the test
     processor._latest_content_id = "MY-OLD"  # noqa: SLF001
 
     calls: list[str] = []
@@ -164,6 +165,56 @@ async def test_apply_active_image_uploads_activates_deletes(processor: SyncThrea
     assert any(d.startswith("select MY-F0009") for d in calls)
     assert any(d.startswith("delete MY-OLD") for d in calls)
     assert processor._latest_content_id == "MY-F0009"  # noqa: SLF001
+    # The TV settles between commands: once before select, once before delete.
+    settles_before_select_and_delete = 2
+    assert processor._settle.await_count == settles_before_select_and_delete  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_apply_active_image_settles_before_switching(processor: SyncThreadProcessor) -> None:
+    """The settle pause is inserted after upload and before select_image."""
+    photo = SimpleNamespace(composite_id="local:1")
+    photo_bytes = SimpleNamespace(data=b"x", file_type_suffix="jpg", width=1920, height=1080)
+    processor._fetch_photo_bytes = AsyncMock(return_value=photo_bytes)  # noqa: SLF001
+    processor._latest_content_id = None  # noqa: SLF001 -- no previous image, so no delete
+
+    events: list[str] = []
+    processor._settle = AsyncMock(side_effect=lambda: events.append("settle"))  # noqa: SLF001
+
+    async def fake_run(fn, *, description, timeout):  # noqa: ANN001, ANN202, ARG001, ASYNC109
+        events.append(description.split()[0])
+        return "MY-F0009" if description.startswith("upload") else None
+
+    processor._run_tv_op = fake_run  # noqa: SLF001
+
+    await processor.apply_active_image(photo)
+
+    # Upload happens, then the settle pause, then the switch.
+    assert events == ["upload", "settle", "select"]
+
+
+@pytest.mark.asyncio
+async def test_settle_sleeps_when_delay_positive(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """_settle sleeps for tv_command_delay seconds when it is positive."""
+    monkeypatch.setattr("framegallery.frame_connector.processors.base.settings.tv_command_delay", 1.5)
+    sleep = AsyncMock()
+    monkeypatch.setattr("framegallery.frame_connector.processors.base.asyncio.sleep", sleep)
+
+    await processor._settle()  # noqa: SLF001
+
+    sleep.assert_awaited_once_with(1.5)
+
+
+@pytest.mark.asyncio
+async def test_settle_is_noop_when_delay_zero(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """_settle does not sleep when the delay is disabled (0)."""
+    monkeypatch.setattr("framegallery.frame_connector.processors.base.settings.tv_command_delay", 0)
+    sleep = AsyncMock()
+    monkeypatch.setattr("framegallery.frame_connector.processors.base.asyncio.sleep", sleep)
+
+    await processor._settle()  # noqa: SLF001
+
+    sleep.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The Frame TV regularly crashes out of Art Mode back to regular television during slideshow image changes. Testing both the `single_async` and `sync_thread` upload processors showed the same behaviour, pointing at a race in the upload → switch sequence rather than the transport.

## Root cause

Both single-image processors fire `upload → select_image → delete` back-to-back with **zero delay**:

- `single_async.py` — `select_image` is called the instant `upload` returns a `content_id`
- `sync_thread.py` — same ordering

The subtlety is in the `samsungtvws` client: `upload()` blocks until the TV emits `image_added`, but that event only means the file was **received/stored** — not that Art Mode has finished indexing and rendering it. `select_image` then fires with only a ~2s ack window (and silently swallows a timeout). A Frame still digesting the upload gets hit with the switch (and then a delete), which is where Art Mode crashes.

The codebase already had corroborating evidence: `batch_slideshow` deliberately waits `_ROTATION_SETTLE_SECONDS = 5` after an upload burst — *"Give the TV a moment to finish digesting the uploads."* The single-image paths never got that treatment.

## Fix

A shared `_settle()` helper on the `UploadProcessor` base, inserted between each TV command (after upload → before select, and before delete). Driven by a new `tv_command_delay` setting:

- **Default `5.0` seconds**
- Set to `0` to restore the original back-to-back behaviour
- Applies to `single_async` and `sync_thread` (`batch_slideshow` already has its own settle logic)

## Changes

- `config.py` — new `tv_command_delay: float = 5.0`
- `processors/base.py` — `_settle()` helper
- `processors/single_async.py` & `processors/sync_thread.py` — settle before select and before delete
- `.env.dist`, `README.md` — documented the setting
- `tests/.../test_sync_thread.py` — 3 new tests (command ordering with settle, positive-delay sleep, zero-delay no-op)

## Testing

- `uv run pytest` — 177 passed
- `uv run ruff check` — clean

Since the processor is built at startup, restart the backend to pick this up. Start at 5s; if crashes stop you can probe downward to find the minimum your Frame tolerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)