### PR TITLE
fix: local library selection follows the active filter again

### DIFF
--- a/framegallery/libraries/factory.py
+++ b/framegallery/libraries/factory.py
@@ -10,6 +10,7 @@ from framegallery.libraries.immich_client import ImmichClient
 from framegallery.libraries.immich_library import ImmichLibrary
 from framegallery.libraries.local_library import LocalLibrary
 from framegallery.models import Library as LibraryModel
+from framegallery.repository.config_repository import ConfigKey, ConfigRepository
 from framegallery.repository.filter_repository import FilterRepository
 from framegallery.repository.image_repository import ImageRepository
 
@@ -37,10 +38,18 @@ def _close_client_soon(client: ImmichClient) -> None:
 
 
 def _build_local(row: LibraryModel, session: Session, image_repository: ImageRepository) -> LocalLibrary:
-    filter_id = row.config.get("filter_id") if row.config else None
+    """
+    Build the local library, driven by the globally active filter.
+
+    The active filter lives in ``config.active_filter`` because that is what the Filters page
+    writes when you star a filter, and it is the only filter selection the UI exposes. Reading it
+    here (rather than from a per-library ``filter_id``) keeps a single source of truth, so starring
+    a filter takes effect on the next slideshow pick.
+    """
+    active_filter_id = ConfigRepository(session).get_or(ConfigKey.ACTIVE_FILTER, default_value=None).value
     filter_query: str | None = None
-    if filter_id is not None:
-        stored_filter = FilterRepository(session).get_filter(int(filter_id))
+    if active_filter_id not in (None, ""):
+        stored_filter = FilterRepository(session).get_filter(int(active_filter_id))
         filter_query = stored_filter.query if stored_filter is not None else None
     return LocalLibrary(image_repository, session, filter_query, row.library_id)
 

--- a/framegallery/models.py
+++ b/framegallery/models.py
@@ -76,6 +76,7 @@ class Library(Base):
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     # Relative selection weight; the effective probability is weight * matching_photo_count.
     weight: Mapped[float] = mapped_column(Float, default=1.0)
-    # Per-source configuration. local: {"filter_id": int|null};
+    # Per-source configuration. local: {} — its selection follows the globally active filter
+    # (config.active_filter), set from the Filters page.
     # immich: {"base_url": str, "api_key": str, "album_ids": [str, ...]}.
     config: Mapped[dict] = mapped_column(JSON, default=dict)

--- a/framegallery/routers/libraries.py
+++ b/framegallery/routers/libraries.py
@@ -33,7 +33,6 @@ def _to_summary(library: Library) -> LibrarySummary:
         has_api_key=bool(config.get("api_key")),
         base_url=config.get("base_url"),
         album_ids=config.get("album_ids", []),
-        filter_id=config.get("filter_id"),
     )
 
 
@@ -109,8 +108,6 @@ def update_library(
         config["api_key"] = payload.api_key
     if payload.album_ids is not None:
         config["album_ids"] = payload.album_ids
-    if payload.filter_id is not None:
-        config["filter_id"] = payload.filter_id
     library.config = config
 
     return _to_summary(library_repository.save(library))

--- a/framegallery/schemas.py
+++ b/framegallery/schemas.py
@@ -115,7 +115,6 @@ class LibrarySummary(BaseModel):
     has_api_key: bool
     base_url: str | None = None
     album_ids: list[str] = Field(default_factory=list)
-    filter_id: int | None = None
 
 
 class LibraryStatus(BaseModel):
@@ -150,7 +149,6 @@ class LibraryUpdate(BaseModel):
     # Only sent when the user wants to change the key; omitted keeps the stored one.
     api_key: str | None = None
     album_ids: list[str] | None = None
-    filter_id: int | None = None
 
 
 class ImmichConnectionRequest(BaseModel):

--- a/tests/unit/framegallery/libraries/test_factory.py
+++ b/tests/unit/framegallery/libraries/test_factory.py
@@ -8,6 +8,7 @@ from framegallery.libraries.factory import build_library
 from framegallery.libraries.immich_library import ImmichLibrary
 from framegallery.libraries.local_library import LocalLibrary
 from framegallery.models import Base, Filter, Library
+from framegallery.repository.config_repository import ConfigKey, ConfigRepository
 from framegallery.repository.image_repository import ImageRepository
 
 
@@ -27,22 +28,54 @@ def db_session(engine: Engine) -> Session:
         session.rollback()
 
 
-def test_build_local_library_with_filter(db_session: Session) -> None:
-    """A local row resolves its configured filter's query into a LocalLibrary."""
-    filter_row = Filter(name="wide", query='{"combinator":"and","rules":[]}')
-    db_session.add(filter_row)
-    db_session.commit()
-    row = Library(
+def _local_row() -> Library:
+    return Library(
         library_id="local",
         name="Local",
         source_type="local",
         enabled=True,
         weight=1.0,
-        config={"filter_id": filter_row.id},
+        config={},
     )
 
-    library = build_library(row, db_session, ImageRepository(db_session), {})
+
+def test_build_local_library_uses_active_filter(db_session: Session) -> None:
+    """The local library picks up the globally active filter's query."""
+    filter_row = Filter(name="wide", query='{"combinator":"and","rules":[]}')
+    db_session.add(filter_row)
+    db_session.commit()
+    ConfigRepository(db_session).set(ConfigKey.ACTIVE_FILTER, str(filter_row.id))
+
+    library = build_library(_local_row(), db_session, ImageRepository(db_session), {})
     assert isinstance(library, LocalLibrary)
+    assert library._filter_query == filter_row.query  # noqa: SLF001
+
+
+def test_build_local_library_follows_active_filter_change(db_session: Session) -> None:
+    """Starring a different filter changes local selection on the next build (regression)."""
+    all_photos = Filter(name="All", query='{"combinator":"and","rules":[]}')
+    holiday = Filter(
+        name="Sicily",
+        query='{"combinator":"and","rules":[{"field":"directory","operator":"contains","value":"sicily"}]}',
+    )
+    db_session.add_all([all_photos, holiday])
+    db_session.commit()
+    config_repository = ConfigRepository(db_session)
+
+    config_repository.set(ConfigKey.ACTIVE_FILTER, str(all_photos.id))
+    first = build_library(_local_row(), db_session, ImageRepository(db_session), {})
+    config_repository.set(ConfigKey.ACTIVE_FILTER, str(holiday.id))
+    second = build_library(_local_row(), db_session, ImageRepository(db_session), {})
+
+    assert first._filter_query == all_photos.query  # noqa: SLF001
+    assert second._filter_query == holiday.query  # noqa: SLF001
+
+
+def test_build_local_library_without_active_filter(db_session: Session) -> None:
+    """With no filter starred, the local library selects from the whole gallery."""
+    library = build_library(_local_row(), db_session, ImageRepository(db_session), {})
+    assert isinstance(library, LocalLibrary)
+    assert library._filter_query is None  # noqa: SLF001
 
 
 def test_build_immich_library_and_cache_reuse(db_session: Session) -> None:

--- a/tests/unit/framegallery/routers/test_libraries_router.py
+++ b/tests/unit/framegallery/routers/test_libraries_router.py
@@ -32,7 +32,7 @@ def db_session() -> Generator[Session, None, None]:
                 source_type="local",
                 enabled=True,
                 weight=1.0,
-                config={"filter_id": None},
+                config={},
             )
         )
         session.commit()

--- a/ui/src/models/Library.ts
+++ b/ui/src/models/Library.ts
@@ -10,7 +10,6 @@ export interface LibrarySummary {
   has_api_key: boolean;
   base_url?: string | null;
   album_ids: string[];
-  filter_id?: number | null;
 }
 
 export interface LibraryCreate {
@@ -30,7 +29,6 @@ export interface LibraryUpdate {
   base_url?: string;
   api_key?: string;
   album_ids?: string[];
-  filter_id?: number | null;
 }
 
 export interface LibraryStatus {


### PR DESCRIPTION
## Problem

Starring a filter on the Filters page no longer changed which local photos the slideshow picked.

The external-libraries refactor (#556) introduced a **second, competing source of truth** for the active filter:

| | writes | reads |
|---|---|---|
| Filters page (star button) | `config.active_filter` | — |
| `LocalLibrary` selection | — | `libraries[local].config.filter_id` |

The migration seeded `filter_id` **once** from the then-current active filter, and nothing ever wrote it again — the only writer was `PUT /api/libraries/{pk}`, which no UI sends `filter_id` to. So local selection froze at whatever filter was active on upgrade day.

The Libraries page already told users *"Selection is controlled by the active filter"* and linked to /filters, so the intent was right and only the wiring was wrong.

**Observed on a live install:**

```
config.active_filter       = '5'  -> "Sicilie 2025"    <- what the user starred
libraries[local].filter_id = 2    -> "All" (no rules)  <- what was actually used
```

Filter 2 has an empty rule set, so the slideshow drew from all 2472 photos instead of the intended 613.

## Fix

- `_build_local` reads `ConfigKey.ACTIVE_FILTER`, matching what the UI actually exposes.
- Removed the vestigial `filter_id` plumbing (`LibrarySummary`, `LibraryUpdate`, router, TS model, column comment) so the two sources of truth cannot drift apart again.

The filter remains **local-only**, which is all we can filter on today — Immich libraries continue to select by album.

## Verification

Ran against a copy of the live database with the fix applied:

```
resolved filter query: ...{"field":"directory","operator":"contains","value":"Sicilie"}
matching local photos: 613
  picked: 2025_Sicilie_549.jpg / 2025_Sicilie_151.jpg / 2025_Sicilie_052.jpg
```

Added regression coverage that a starred-filter change takes effect on the next build, and that an unset active filter selects from the whole gallery.

179 backend tests, 40 frontend tests, ruff + eslint clean, frontend builds.

## Note for deployers

The stale `{"filter_id": N}` left in existing `libraries` rows is now ignored and harmless — no migration included. Say the word if you'd prefer one that scrubs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)