### PR TITLE
feat: art-mode watchdog and TV watch mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ upload_processor=single_async
 # processors (single_async/sync_thread). Guards against Art Mode crashing when the
 # switch command is sent before the TV has finished digesting the upload. 0 disables.
 tv_command_delay=5.0
+# Art-mode watchdog: periodically checks whether the TV is reachable and still in art
+# mode. See the "Art-mode watchdog" section below.
+art_mode_watchdog_enabled=true
+art_mode_poll_interval=60
 
 # Docker Volume Mount Paths (customize for your setup)
 IMAGES_PATH=./images
@@ -226,6 +230,45 @@ Related settings:
 
 In `batch_slideshow` mode the app-driven slideshow loop and the TV auto-cleanup service are
 both suppressed, since the TV owns rotation and the processor manages its own batch.
+
+## Art-mode Watchdog
+
+The Frame leaves art mode for two very different reasons: somebody picks up the remote to
+watch television, or the art system crashes and the TV falls back to regular TV (typically
+Samsung TV Plus). Both look identical from the outside — `get_artmode` simply reports `off`.
+
+The watchdog therefore does **not** try to guess which happened. It probes on an interval and:
+
+- **Pauses slideshow pushes** while art mode is off. Uploads are invisible on regular TV, and
+  issuing them is itself a common way to wedge the Frame. Pushing resumes automatically when
+  art mode comes back — i.e. when you finish watching and switch back.
+- **Detects a wedged art channel and rebuilds the connection.** It probes power state over
+  REST (`/api/v2/`, a plain HTTP GET) *separately* from the art WebSocket. That is what
+  distinguishes "the TV is fine but art mode has crashed" from "the TV is gone entirely" —
+  a distinction ICMP cannot make, since a Frame in standby still answers ping.
+
+| Health | Meaning |
+|---|---|
+| `art_on` | Reachable and displaying art. The normal state. |
+| `tv_mode` | Reachable, art mode off. Someone is watching TV, or art mode crashed. |
+| `standby` | Reachable but powered down. Normal overnight. |
+| `art_unavailable` | REST answers but the art channel does not — the art system has wedged. |
+| `unreachable` | No response at all: powered off, rebooting, or off the network. |
+
+**Art mode is only forced back on immediately after our own writes.** After each
+upload/select/delete sequence the processor re-checks art mode; finding it off at that
+moment means *we* knocked the TV out of it, so restoring cannot be fighting a person who
+just reached for the remote. The periodic poll deliberately never restores art mode.
+
+The trade-off: an art-mode crash that happens *between* writes is indistinguishable from
+someone watching TV, so the Frame will stay on regular TV until you switch it back. Making
+the poll restore art mode too would close that gap at the cost of overriding you every time
+you sit down to watch something.
+
+| Variable | Default | Description |
+|---|---|---|
+| `art_mode_watchdog_enabled` | `true` | Enable the watchdog. With it off, nothing observes art mode and `/api/status` reports the art-mode fields as unknown. |
+| `art_mode_poll_interval` | `60` | Seconds between probes. |
 
 ## Photo Libraries
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,22 @@ you sit down to watch something.
 | `art_mode_watchdog_enabled` | `true` | Enable the watchdog. With it off, nothing observes art mode and `/api/status` reports the art-mode fields as unknown. |
 | `art_mode_poll_interval` | `60` | Seconds between probes. |
 
+### TV Watch Mode
+
+The **Settings** page has a **TV Watch Mode** toggle for when you want to watch television
+and be certain the app will not interfere. While it is on:
+
+- no images are pushed to the TV at all, and
+- art mode is **never** restored — including immediately after our own writes, the one
+  case where the app would otherwise be confident it should intervene.
+
+It is checked *before* the art-mode state, so it does not depend on art-mode detection
+being accurate or up to date. Turn it off and the slideshow resumes on the next tick.
+
+This is a runtime setting stored in the database (`tv_watch_mode_enabled`), not an
+environment variable, so it can be toggled without a restart. It is also available at
+`GET`/`POST /api/config/tv_watch_mode_enabled`.
+
 ## Photo Libraries
 
 The slideshow can draw photos from multiple **libraries** at once, managed on the **Libraries** page.

--- a/framegallery/config.py
+++ b/framegallery/config.py
@@ -50,6 +50,14 @@ class Settings(BaseSettings):
     # minutes, so the 180s slideshow_interval doesn't apply in this mode).
     batch_size: int = 50
     batch_rotation_minutes: int = 3
+    # Art-mode watchdog: periodically probe whether the TV is reachable and still in
+    # art mode, pausing slideshow pushes while it is showing regular television and
+    # rebuilding the connection when the art channel wedges. It never forces art mode
+    # back on from this poll -- between our own writes an "off" is indistinguishable
+    # from someone choosing to watch TV. Art mode is only restored immediately after
+    # our own writes, where we know we caused it.
+    art_mode_watchdog_enabled: bool = True
+    art_mode_poll_interval: int = 60
 
     @property
     def database_path(self) -> str:

--- a/framegallery/frame_connector/art_mode_watchdog.py
+++ b/framegallery/frame_connector/art_mode_watchdog.py
@@ -1,0 +1,158 @@
+"""
+Periodic health probe for the TV's art mode.
+
+The Frame drops out of art mode for two very different reasons: somebody picks up the
+remote to watch television, or the art system crashes and the TV falls back to regular
+TV (typically Samsung TV Plus). From the outside these look identical -- ``get_artmode``
+simply reports ``off`` in both cases -- so this watchdog never tries to guess between
+them. It observes, gates the slideshow, and recovers the *connection*; the one place
+art mode is forced back on is immediately after our own writes, where causation is
+established by construction (see ``UploadProcessor.verify_art_mode_after_write``).
+
+What it does resolve is the far more important distinction between "the TV is fine but
+art mode is off" and "the TV is not answering at all", by probing REST power state
+separately from the art WebSocket. That is what lets a wedged art channel be detected
+and reconnected instead of silently retrying into a dead socket every slideshow tick.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from framegallery.frame_connector.processors import UploadProcessor
+
+logger = logging.getLogger("framegallery")
+
+
+class TvHealth(str, Enum):
+    """Coarse health of the TV as seen from the app."""
+
+    UNKNOWN = "unknown"
+    """Nothing has been probed yet."""
+
+    ART_ON = "art_on"
+    """Reachable and displaying art. The normal state."""
+
+    TV_MODE = "tv_mode"
+    """Reachable, art mode off. Someone is watching television, or art mode crashed."""
+
+    STANDBY = "standby"
+    """Reachable but powered down (screen off). Normal overnight."""
+
+    ART_UNAVAILABLE = "art_unavailable"
+    """REST answers but the art channel does not -- the art system has wedged."""
+
+    UNREACHABLE = "unreachable"
+    """No response at all: powered off at the socket, rebooting, or off the network."""
+
+
+# States in which the TV connection is worth tearing down so the reconnection pinger
+# rebuilds it. A wedged art channel does not heal on its own.
+_RECOVERABLE = frozenset({TvHealth.ART_UNAVAILABLE, TvHealth.UNREACHABLE})
+
+
+def _art_mode_for(health: TvHealth) -> bool | None:
+    """
+    Map a health state onto a cached art-mode value.
+
+    Only ART_ON and TV_MODE are confident readings. Every other state means we could
+    not actually observe art mode, and must report None rather than a misleading
+    False -- a False would gate the slideshow off (see ``art_mode_permits_upload``).
+    """
+    if health is TvHealth.ART_ON:
+        return True
+    if health is TvHealth.TV_MODE:
+        return False
+    return None
+
+
+class ArtModeWatchdog:
+    """Polls TV/art-mode health and keeps the processor's cached state fresh."""
+
+    def __init__(self, processor: UploadProcessor, poll_interval: float) -> None:
+        self._processor = processor
+        self._poll_interval = poll_interval
+        self._health = TvHealth.UNKNOWN
+
+    @property
+    def health(self) -> TvHealth:
+        """The most recently observed health state."""
+        return self._health
+
+    async def run_periodic_probe(self) -> None:
+        """Probe forever. A failing probe must never kill the loop."""
+        logger.info("Art-mode watchdog started (every %ss)", self._poll_interval)
+        while True:
+            try:
+                await self.probe_once()
+            except Exception:
+                logger.exception("Art-mode watchdog probe failed; will retry next cycle")
+            await asyncio.sleep(self._poll_interval)
+
+    async def probe_once(self) -> TvHealth:
+        """Run a single probe, update cached state, and recover the connection if needed."""
+        health = await self._classify()
+        previous, self._health = self._health, health
+
+        if health != previous:
+            self._log_transition(previous, health)
+
+        # Only art mode being *confidently* off should gate uploads. Everything else is
+        # either fine or a connection problem, which the processor's own guards handle.
+        self._processor.note_art_mode(active=_art_mode_for(health))
+
+        # Re-arm the connection only on entering a bad state, not on every poll: the
+        # reconnection pinger is already running while disconnected, and closing
+        # repeatedly would fight it (and spam the log overnight).
+        if health in _RECOVERABLE and previous not in _RECOVERABLE:
+            await self._recover_connection(health)
+
+        return health
+
+    async def _classify(self) -> TvHealth:
+        """Probe REST first, then the art channel, and map the pair onto a health state."""
+        powered = await self._processor.is_tv_powered_on()
+        if powered is None:
+            return TvHealth.UNREACHABLE
+        if not powered:
+            return TvHealth.STANDBY
+
+        art_mode = await self._processor.get_art_mode()
+        if art_mode is None:
+            # REST answered but the art channel did not: the TV is alive and the art
+            # system specifically has wedged. This is the signature of an Art Mode
+            # crash, as opposed to the TV being off or someone watching television.
+            return TvHealth.ART_UNAVAILABLE
+        return TvHealth.ART_ON if art_mode else TvHealth.TV_MODE
+
+    async def _recover_connection(self, health: TvHealth) -> None:
+        """Drop the TV connection so the reconnection pinger rebuilds it."""
+        logger.warning("TV health is %s; dropping the connection so it gets rebuilt", health.value)
+        try:
+            await self._processor.close()
+        except Exception:
+            logger.exception("Failed to close the TV connection during art-mode recovery")
+
+    def _log_transition(self, previous: TvHealth, current: TvHealth) -> None:
+        """Log a health change, loudly enough to correlate with a Frame falling over."""
+        if current is TvHealth.TV_MODE:
+            logger.warning(
+                "TV is no longer in art mode (%s -> %s). Treating this as someone watching "
+                "television and pausing slideshow pushes; it will resume automatically when "
+                "art mode returns. Note an art-mode crash between writes is indistinguishable "
+                "from this and would look the same.",
+                previous.value,
+                current.value,
+            )
+        elif current is TvHealth.ART_UNAVAILABLE:
+            logger.error(
+                "TV answers over REST but its art channel does not (%s -> %s): the art system has most likely crashed.",
+                previous.value,
+                current.value,
+            )
+        else:
+            logger.info("TV health: %s -> %s", previous.value, current.value)

--- a/framegallery/frame_connector/processors/base.py
+++ b/framegallery/frame_connector/processors/base.py
@@ -16,6 +16,7 @@ from samsungtvws.rest import SamsungTVRest
 from framegallery.aspect_ratio import get_aspect_ratio
 from framegallery.config import settings
 from framegallery.logging_config import setup_logging
+from framegallery.repository.config_repository import ConfigKey, read_bool_setting
 
 if TYPE_CHECKING:
     from framegallery.libraries.base import PhotoBytes, PhotoRef
@@ -154,16 +155,32 @@ class UploadProcessor(abc.ABC):
         """Record the art-mode state observed by the watchdog or a post-write check."""
         self._art_mode_active = active
 
+    def tv_watch_mode_enabled(self) -> bool:
+        """
+        Whether the user has explicitly claimed the TV to watch television.
+
+        Read live from the database on every call rather than cached, so toggling it
+        in the UI takes effect on the next push instead of at the next poll.
+        """
+        return read_bool_setting(ConfigKey.TV_WATCH_MODE_ENABLED, default=False)
+
     def art_mode_permits_upload(self) -> bool:
         """
         Whether pushing an image to the TV is worthwhile right now.
 
-        Only a *known* "off" suppresses the push: while the TV is showing regular
-        television our uploads are invisible, and issuing them is what tends to wedge
-        the Frame in the first place. An unknown state (nothing has polled yet, or the
-        query failed) stays permissive so a watchdog problem can never silently freeze
-        the slideshow.
+        TV watch mode is a hard stop: the user has said the TV is theirs, so the app
+        stays off it entirely regardless of what art mode reports. This is checked
+        first precisely so the toggle does not depend on art-mode detection being
+        accurate or up to date.
+
+        Failing that, only a *known* art-mode "off" suppresses the push: while the TV
+        is showing regular television our uploads are invisible, and issuing them is
+        what tends to wedge the Frame in the first place. An unknown state (nothing has
+        polled yet, or the query failed) stays permissive so a watchdog problem can
+        never silently freeze the slideshow.
         """
+        if self.tv_watch_mode_enabled():
+            return False
         return self._art_mode_active is not False
 
     async def get_art_mode(self) -> bool | None:
@@ -221,6 +238,13 @@ class UploadProcessor(abc.ABC):
         active = await self.get_art_mode()
         self.note_art_mode(active=active)
         if active is not False:
+            return
+
+        # TV watch mode is an explicit instruction to leave the TV alone. Honour it
+        # even here, where we know we caused the drop: the user would rather keep
+        # watching than have the app claw the screen back.
+        if self.tv_watch_mode_enabled():
+            logger.info("Art mode is off after our write, but TV watch mode is on; leaving the TV alone.")
             return
 
         logger.warning(

--- a/framegallery/frame_connector/processors/base.py
+++ b/framegallery/frame_connector/processors/base.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from blinker import signal
 from icmplib import ping
 from samsungtvws.async_remote import SamsungTVWSAsyncRemote
+from samsungtvws.rest import SamsungTVRest
 
 from framegallery.aspect_ratio import get_aspect_ratio
 from framegallery.config import settings
@@ -66,6 +67,9 @@ class UploadProcessor(abc.ABC):
 
     IDEAL_ASPECT_RATIO_WIDTH = 16
     IDEAL_ASPECT_RATIO_HEIGHT = 9
+    # Timeout (seconds) for the REST power-state probe. Short: it is a LAN request to
+    # a TV that is either answering promptly or not answering at all.
+    REST_TIMEOUT = 5
 
     def __init__(self, ip_address: str, port: int, library_manager: LibraryManager | None = None) -> None:
         self._ip_address = ip_address
@@ -82,6 +86,10 @@ class UploadProcessor(abc.ABC):
         self._tv_is_online = False
         self._connected = False
         self._latest_content_id: str | None = None
+
+        # Last known art-mode state, refreshed by the ArtModeWatchdog and after our
+        # own writes. None means "not established yet"; see art_mode_permits_upload().
+        self._art_mode_active: bool | None = None
 
         # Deduplicate the reconnection-failure logging: a wedged TV can fail every
         # 10s for hours, so only the first occurrence of a given error gets a full
@@ -134,6 +142,107 @@ class UploadProcessor(abc.ABC):
     @abc.abstractmethod
     async def delete_files(self, content_ids: list[str]) -> dict[str, bool] | None:
         """Delete files from the TV, returning per-id success, or None if unavailable."""
+
+    # --- art mode ---
+
+    @property
+    def art_mode_active(self) -> bool | None:
+        """Last known art-mode state, or None if it has not been established yet."""
+        return self._art_mode_active
+
+    def note_art_mode(self, *, active: bool | None) -> None:
+        """Record the art-mode state observed by the watchdog or a post-write check."""
+        self._art_mode_active = active
+
+    def art_mode_permits_upload(self) -> bool:
+        """
+        Whether pushing an image to the TV is worthwhile right now.
+
+        Only a *known* "off" suppresses the push: while the TV is showing regular
+        television our uploads are invisible, and issuing them is what tends to wedge
+        the Frame in the first place. An unknown state (nothing has polled yet, or the
+        query failed) stays permissive so a watchdog problem can never silently freeze
+        the slideshow.
+        """
+        return self._art_mode_active is not False
+
+    async def get_art_mode(self) -> bool | None:
+        """
+        Return whether the TV is in art mode, or None if it cannot be determined.
+
+        None specifically means "we could not ask" -- the art channel is unreachable
+        -- which is a different condition from a confident False, and the watchdog
+        treats the two very differently. Processors that own an art client override
+        this; the default reports "unknown".
+        """
+        return None
+
+    async def set_art_mode(self, *, enabled: bool) -> bool:
+        """
+        Ask the TV to enter or leave art mode; return whether the command was accepted.
+
+        Overridden by processors that own an art client.
+        """
+        _ = enabled
+        return False
+
+    async def is_tv_powered_on(self) -> bool | None:
+        """
+        Report the TV's power state over REST, or None if it is unreachable.
+
+        This deliberately avoids the art WebSocket: it is a plain HTTP GET to
+        ``/api/v2/``, so it still answers when the art channel has wedged. That makes
+        it the only probe that can tell "the whole TV is gone" apart from "the TV is
+        fine but art mode has crashed". ICMP is not a substitute -- a Frame in standby
+        still replies to ping.
+        """
+
+        def _probe() -> bool:
+            rest = SamsungTVRest(self._ip_address, self._port, self.REST_TIMEOUT)
+            return rest.rest_power_state()
+
+        try:
+            return await asyncio.to_thread(_probe)
+        except Exception:  # noqa: BLE001 -- any failure here means "unreachable", by design
+            logger.debug("REST power-state probe failed for %s", self._ip_address, exc_info=True)
+            return None
+
+    async def verify_art_mode_after_write(self) -> None:
+        """
+        Re-check art mode straight after our own TV writes, and restore it if it dropped.
+
+        This is the only path that force-enables art mode, and the timing is the whole
+        point: finding it off immediately after our upload/select/delete sequence means
+        *we* knocked the Frame out of art mode, so turning it back on cannot be fighting
+        someone who just picked up the remote. The periodic watchdog deliberately never
+        does this -- between writes an "off" is indistinguishable from a person choosing
+        to watch television, and the safe assumption there is that a human did it.
+        """
+        active = await self.get_art_mode()
+        self.note_art_mode(active=active)
+        if active is not False:
+            return
+
+        logger.warning(
+            "Art mode dropped during our own TV commands -- the Frame fell back to "
+            "regular TV. Attempting to restore art mode."
+        )
+        if not await self.set_art_mode(enabled=True):
+            logger.error("Failed to restore art mode after write; the TV is left on regular TV.")
+            return
+
+        # The TV accepting set_artmode is not the same as it acting on it, so confirm
+        # rather than assuming -- otherwise a Frame that is wedged badly enough to
+        # ignore the command would still be reported as recovered.
+        restored = await self.get_art_mode()
+        self.note_art_mode(active=restored)
+        if restored:
+            logger.info("Art mode restored after write.")
+        else:
+            logger.error(
+                "Art mode restore was accepted but the TV is still not in art mode (now %s); it is left on regular TV.",
+                restored,
+            )
 
     # --- optional diagnostics ---
 

--- a/framegallery/frame_connector/processors/single_async.py
+++ b/framegallery/frame_connector/processors/single_async.py
@@ -92,24 +92,44 @@ class SingleAsyncProcessor(UploadProcessor):
 
         return data
 
-    async def _is_art_mode_active(self) -> bool:
+    async def get_art_mode(self) -> bool | None:
         """
-        Return whether the TV is currently in art mode.
+        Return whether the TV is currently in art mode, or None if it cannot be asked.
 
-        The cached `self._tv.art_mode` flag is only updated from push events
-        (e.g. `art_mode_changed`), so it can be stale when the app connected
-        while the TV was already in art mode, or when a transition event was
-        missed. Query the live status and fall back to the cached flag only if
-        the query fails.
+        The cached ``self._tv.art_mode`` flag is only updated from push events (e.g.
+        ``art_mode_changed``), so it can be stale when the app connected while the TV
+        was already in art mode, or when a transition event was missed. Query the live
+        status instead, and report None rather than a cached guess when the query
+        fails: the watchdog distinguishes "art mode is off" from "the art channel is
+        not answering", and a stale flag would blur exactly that distinction.
         """
+        if self._tv is None or not self._connected:
+            return None
         try:
             return await self._tv.get_artmode() == "on"
         except (AssertionError, KeyError, OSError, websockets.exceptions.WebSocketException):
-            logger.debug(
-                "Live art-mode query failed; falling back to cached art_mode=%s",
-                self._tv.art_mode,
-            )
-            return bool(self._tv.art_mode)
+            logger.debug("Live art-mode query failed (cached art_mode=%s)", getattr(self._tv, "art_mode", None))
+            return None
+
+    async def set_art_mode(self, *, enabled: bool) -> bool:
+        """Switch art mode on or off, reporting whether the command went through."""
+        if self._tv is None or not self._connected:
+            return False
+        try:
+            await self._tv.set_artmode("on" if enabled else "off")
+        except (AssertionError, KeyError, OSError, websockets.exceptions.WebSocketException):
+            logger.exception("Failed to set art mode to %s", enabled)
+            return False
+        return True
+
+    async def _is_art_mode_active(self) -> bool:
+        """
+        Return whether art mode is active, treating an unanswerable query as active.
+
+        Kept permissive so a failed query never silently freezes the slideshow; the
+        watchdog is what turns a genuine "off" into a suppressed push.
+        """
+        return await self.get_art_mode() is not False
 
     async def apply_active_image(self, photo: PhotoRef) -> None:  # noqa: PLR0911, C901
         """Upload the given photo to the TV, activate it, and delete the previous one."""
@@ -162,6 +182,11 @@ class SingleAsyncProcessor(UploadProcessor):
             logger.error("Slideshow image upload completed but did not return a content_id.")
         else:
             logger.error("Slideshow image upload failed, data is None.")
+
+        # Confirm the Frame is still in art mode after our command sequence: crashing
+        # out of it is exactly what this sequence provokes.
+        await self._settle()
+        await self.verify_art_mode_after_write()
 
     async def _upload_photo(self, photo: PhotoRef, photo_bytes: PhotoBytes) -> dict | None:
         """Upload photo bytes to TV and return the uploaded file details as provided by the television."""

--- a/framegallery/frame_connector/processors/sync_thread.py
+++ b/framegallery/frame_connector/processors/sync_thread.py
@@ -194,6 +194,10 @@ class SyncThreadProcessor(UploadProcessor):
         if not self._connected:
             return
 
+        if not self.art_mode_permits_upload():
+            logger.debug("sync_thread: TV is not in art mode, skipping image update.")
+            return
+
         logger.info("sync_thread: updating active image on TV: %s", photo.composite_id)
 
         photo_bytes = await self._fetch_photo_bytes(photo)
@@ -239,6 +243,12 @@ class SyncThreadProcessor(UploadProcessor):
         except Exception:
             logger.exception("sync_thread: activate/cleanup failed for %s", content_id)
 
+        # Whether or not the sequence above succeeded, confirm the Frame is still in
+        # art mode: crashing out of it is exactly the failure this sequence provokes,
+        # and a failed select/delete makes that *more* likely, not less.
+        await self._settle()
+        await self.verify_art_mode_after_write()
+
     async def get_active_item_details(self) -> dict | None:
         """Get the current active item details from the TV."""
         if not self._connected:
@@ -250,6 +260,41 @@ class SyncThreadProcessor(UploadProcessor):
         except Exception:
             logger.exception("sync_thread: failed to get current active item")
             return None
+
+    # --- art mode ---
+
+    async def get_art_mode(self) -> bool | None:
+        """Query live art-mode state, or None if the art channel cannot answer."""
+        if not self._connected:
+            return None
+        try:
+            value = await self._run_tv_op(
+                lambda art: art.get_artmode(), description="get_artmode", timeout=self.OP_TIMEOUT
+            )
+        except Exception:  # noqa: BLE001 -- any failure means "cannot determine", by design
+            logger.debug("sync_thread: art-mode query failed", exc_info=True)
+            return None
+        if value is None:
+            # _run_tv_op yields None when it exhausts its retries without raising.
+            # That is "no answer", not "art mode is off": reporting False here would
+            # gate the slideshow off and trigger a spurious art-mode restore.
+            return None
+        return value == "on"
+
+    async def set_art_mode(self, *, enabled: bool) -> bool:
+        """Switch art mode on or off, reporting whether the command went through."""
+        if not self._connected:
+            return False
+        try:
+            await self._run_tv_op(
+                lambda art: art.set_artmode("on" if enabled else "off"),
+                description=f"set_artmode {'on' if enabled else 'off'}",
+                timeout=self.OP_TIMEOUT,
+            )
+        except Exception:
+            logger.exception("sync_thread: failed to set art mode to %s", enabled)
+            return False
+        return True
 
     # --- generic TV file ops ---
 

--- a/framegallery/main.py
+++ b/framegallery/main.py
@@ -29,6 +29,7 @@ from framegallery.dependencies import (
     get_library_manager,
     get_slideshow_instance,
 )
+from framegallery.frame_connector.art_mode_watchdog import ArtModeWatchdog, TvHealth
 from framegallery.frame_connector.processors import ProcessorKind, UploadProcessor, api_version, build_processor
 from framegallery.frame_connector.status import SlideshowStatus, Status
 from framegallery.importer2.importer import Importer
@@ -127,6 +128,27 @@ async def update_slideshow_periodically(slideshow: Slideshow, processor: UploadP
         await asyncio.sleep(settings.slideshow_interval)
 
 
+def _start_art_mode_watchdog(app: FastAPI, processor: UploadProcessor) -> None:
+    """
+    Start the art-mode watchdog and expose it on the app state.
+
+    It owns no TV connection of its own; it probes through the processor and keeps the
+    processor's cached art-mode state fresh, so the slideshow can be gated (and
+    /api/status served) without a TV round trip per push or per request.
+    """
+    if not settings.art_mode_watchdog_enabled:
+        app.state.art_mode_watchdog = None
+        logger.info("Art-mode watchdog is disabled")
+        return
+
+    watchdog = ArtModeWatchdog(processor, settings.art_mode_poll_interval)
+    app.state.art_mode_watchdog = watchdog
+    logger.info("Scheduling the art-mode watchdog")
+    task = asyncio.create_task(watchdog.run_periodic_probe())
+    background_tasks.add(task)
+    task.add_done_callback(background_tasks.discard)
+
+
 def _raise_migration_error() -> None:
     """Raise migration error."""
     msg = "Database migrations failed"
@@ -195,6 +217,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Instantiate and store the new SSE signal listener
     app.state.slideshow_signal_sse_listener = SlideshowSignalSSEListener(slideshow_event_queue)
+
+    _start_art_mode_watchdog(app, upload_processor)
 
     # Start TV auto-cleanup service
     cleanup_service = TvCleanupService(upload_processor, config_repository)
@@ -325,11 +349,23 @@ else:
 
 @app.get("/api/status")
 async def status() -> Status:
-    """Return the application state. Stubbed for now."""
+    """
+    Return the observed TV state.
+
+    Served from the art-mode watchdog's cached reading rather than probing the TV per
+    request, so polling this endpoint cannot add load to a Frame that is already
+    struggling. With the watchdog disabled there is nothing observing the TV, so the
+    art-mode fields report None (unknown) rather than inventing a value.
+    """
+    watchdog: ArtModeWatchdog | None = getattr(app.state, "art_mode_watchdog", None)
+    if watchdog is None:
+        return Status(tv_on=False, art_mode_supported=True, art_mode_active=None, api_version=api_version)
+
+    health = watchdog.health
     return Status(
-        tv_on=True,
+        tv_on=health not in (TvHealth.UNREACHABLE, TvHealth.STANDBY, TvHealth.UNKNOWN),
         art_mode_supported=True,
-        art_mode_active=True,
+        art_mode_active=app.state.upload_processor.art_mode_active,
         api_version=api_version,
     )
 

--- a/framegallery/main.py
+++ b/framegallery/main.py
@@ -75,13 +75,20 @@ def _should_push_slideshow_tick() -> bool:
 
     - In ``batch_slideshow`` mode the TV owns rotation, so the app must never push
       per-tick (it would fight the TV's own slideshow).
+    - While TV watch mode is on the TV belongs to the viewer, so the whole tick is
+      skipped rather than merely suppressed at the push: advancing the slideshow
+      would keep rewriting the active image and emitting SSE updates for pictures
+      nobody is looking at, and the UI would drift out of step with the screen.
     - Otherwise honour the ``SLIDESHOW_ENABLED`` config flag. This is read from a
       fresh session each tick so runtime enable/disable takes effect immediately.
     """
     if settings.upload_processor == ProcessorKind.BATCH_SLIDESHOW.value:
         return False
     with SessionLocal() as db:
-        return ConfigRepository(db).get_bool(ConfigKey.SLIDESHOW_ENABLED, default=True)
+        config_repo = ConfigRepository(db)
+        if config_repo.get_bool(ConfigKey.TV_WATCH_MODE_ENABLED, default=False):
+            return False
+        return config_repo.get_bool(ConfigKey.SLIDESHOW_ENABLED, default=True)
 
 
 async def _wait_for_processor_connection(
@@ -565,6 +572,7 @@ async def get_settings(
         ).value,
         "active_filter": active_filter,
         "auto_cleanup_enabled": config_repo.get_or(ConfigKey.AUTO_CLEANUP_ENABLED, default_value=False).value,
+        "tv_watch_mode_enabled": config_repo.get_bool(ConfigKey.TV_WATCH_MODE_ENABLED, default=False),
     }
 
     return ConfigResponse(**config)

--- a/framegallery/repository/config_repository.py
+++ b/framegallery/repository/config_repository.py
@@ -17,6 +17,7 @@ class ConfigKey(Enum):
     CURRENT_ACTIVE_IMAGE_SINCE = "current_active_image_since"
     ACTIVE_FILTER = "active_filter"
     AUTO_CLEANUP_ENABLED = "auto_cleanup_enabled"
+    TV_WATCH_MODE_ENABLED = "tv_watch_mode_enabled"
 
 
 class ConfigRepository:
@@ -76,3 +77,20 @@ class ConfigRepository:
     def has(self, key: ConfigKey) -> bool:
         """Check if a configuration value exists by its key."""
         return self.get(key) is not None
+
+
+def read_bool_setting(key: ConfigKey, *, default: bool = False) -> bool:
+    """
+    Read a boolean setting on a short-lived session of its own.
+
+    For callers outside the request cycle -- background loops and the upload
+    processors -- which have no session injected and must observe the *current*
+    value on every check rather than one captured at startup, so that toggling a
+    setting in the UI takes effect immediately.
+    """
+    # Imported here rather than at module scope: framegallery.dependencies pulls in
+    # the upload processors, which in turn read settings through this helper.
+    from framegallery.database import SessionLocal  # noqa: PLC0415
+
+    with SessionLocal() as db:
+        return ConfigRepository(db).get_bool(key, default=default)

--- a/framegallery/repository/config_repository.py
+++ b/framegallery/repository/config_repository.py
@@ -1,11 +1,15 @@
 import json
+import logging
 from enum import Enum
 from typing import Any
 
 from sqlalchemy import delete, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from framegallery.models import Config
+
+logger = logging.getLogger("framegallery")
 
 
 class ConfigKey(Enum):
@@ -81,16 +85,25 @@ class ConfigRepository:
 
 def read_bool_setting(key: ConfigKey, *, default: bool = False) -> bool:
     """
-    Read a boolean setting on a short-lived session of its own.
+    Read a boolean setting on a short-lived session of its own, falling back to ``default``.
 
     For callers outside the request cycle -- background loops and the upload
     processors -- which have no session injected and must observe the *current*
     value on every check rather than one captured at startup, so that toggling a
     setting in the UI takes effect immediately.
+
+    These callers sit on the slideshow hot path, so a database that is missing,
+    locked or mid-migration must not propagate an exception and take the push down
+    with it. Any failure degrades to ``default``, which for every current caller is
+    the permissive value.
     """
     # Imported here rather than at module scope: framegallery.dependencies pulls in
     # the upload processors, which in turn read settings through this helper.
     from framegallery.database import SessionLocal  # noqa: PLC0415
 
-    with SessionLocal() as db:
-        return ConfigRepository(db).get_bool(key, default=default)
+    try:
+        with SessionLocal() as db:
+            return ConfigRepository(db).get_bool(key, default=default)
+    except SQLAlchemyError:
+        logger.warning("Could not read setting %s; falling back to %s", key.value, default, exc_info=True)
+        return default

--- a/framegallery/routers/config.py
+++ b/framegallery/routers/config.py
@@ -51,3 +51,25 @@ def set_auto_cleanup_enabled(
     """Set the auto-cleanup enabled status."""
     config_repository.set(ConfigKey.AUTO_CLEANUP_ENABLED, config_value.value)
     return config_value
+
+
+@router.get("/tv_watch_mode_enabled", response_model=schemas.ConfigValue)
+def get_tv_watch_mode_enabled(
+    config_repository: Annotated[ConfigRepository, Depends(get_config_repository)],
+) -> schemas.ConfigValue:
+    """Get the TV-watch-mode status."""
+    return schemas.ConfigValue(value=config_repository.get_bool(ConfigKey.TV_WATCH_MODE_ENABLED, default=False))
+
+
+@router.post("/tv_watch_mode_enabled", response_model=schemas.ConfigValue)
+def set_tv_watch_mode_enabled(
+    config_value: schemas.ConfigValue, config_repository: Annotated[ConfigRepository, Depends(get_config_repository)]
+) -> schemas.ConfigValue:
+    """
+    Set the TV-watch-mode status.
+
+    While on, the app pushes no images and never restores art mode: the TV belongs to
+    the viewer until they turn this back off.
+    """
+    config_repository.set(ConfigKey.TV_WATCH_MODE_ENABLED, config_value.value)
+    return config_value

--- a/framegallery/schemas.py
+++ b/framegallery/schemas.py
@@ -63,6 +63,7 @@ class ConfigResponse(BaseModel):
     current_active_image_since: str | None
     active_filter: Filter | None
     auto_cleanup_enabled: bool
+    tv_watch_mode_enabled: bool
 
 
 class FilterCreate(BaseModel):

--- a/tests/integration/framegallery/repository/test_config_repository.py
+++ b/tests/integration/framegallery/repository/test_config_repository.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import pytest
 from sqlalchemy import Engine, create_engine
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
+import framegallery.database as database_module
 from framegallery.models import Base
-from framegallery.repository.config_repository import ConfigKey, ConfigRepository
+from framegallery.repository.config_repository import ConfigKey, ConfigRepository, read_bool_setting
 
 
 @pytest.fixture
@@ -40,3 +41,21 @@ def test_get_bool_reads_stored_false(repository: ConfigRepository) -> None:
     """A "false" string reads back False even when the default is True."""
     repository.set(ConfigKey.SLIDESHOW_ENABLED, "false")
     assert repository.get_bool(ConfigKey.SLIDESHOW_ENABLED, default=True) is False
+
+
+def test_read_bool_setting_uses_its_own_session(engine: Engine, monkeypatch) -> None:  # noqa: ANN001
+    """
+    read_bool_setting opens its own session and observes committed values.
+
+    The upload processors and background loops have no session injected, and must see
+    a toggle flipped in the UI on the very next check rather than a value captured at
+    startup.
+    """
+    monkeypatch.setattr(database_module, "SessionLocal", sessionmaker(bind=engine))
+
+    assert read_bool_setting(ConfigKey.TV_WATCH_MODE_ENABLED, default=False) is False
+
+    with Session(engine) as session:
+        ConfigRepository(session).set(ConfigKey.TV_WATCH_MODE_ENABLED, value=True)
+
+    assert read_bool_setting(ConfigKey.TV_WATCH_MODE_ENABLED, default=False) is True

--- a/tests/integration/framegallery/repository/test_config_repository.py
+++ b/tests/integration/framegallery/repository/test_config_repository.py
@@ -59,3 +59,17 @@ def test_read_bool_setting_uses_its_own_session(engine: Engine, monkeypatch) -> 
         ConfigRepository(session).set(ConfigKey.TV_WATCH_MODE_ENABLED, value=True)
 
     assert read_bool_setting(ConfigKey.TV_WATCH_MODE_ENABLED, default=False) is True
+
+
+def test_read_bool_setting_falls_back_when_the_database_is_unusable(monkeypatch) -> None:  # noqa: ANN001
+    """
+    An unreadable database degrades to the default instead of raising.
+
+    This runs on the slideshow hot path via the upload processors, so a database that
+    is missing, locked or mid-migration must not take the push down with it.
+    """
+    broken_engine = create_engine("sqlite:///:memory:")  # no tables created
+    monkeypatch.setattr(database_module, "SessionLocal", sessionmaker(bind=broken_engine))
+
+    assert read_bool_setting(ConfigKey.TV_WATCH_MODE_ENABLED, default=False) is False
+    assert read_bool_setting(ConfigKey.SLIDESHOW_ENABLED, default=True) is True

--- a/tests/unit/framegallery/frame_connector/processors/test_art_mode.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_art_mode.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from framegallery.frame_connector.processors import base
 from framegallery.frame_connector.processors.sync_thread import SyncThreadProcessor
 
 
@@ -18,6 +19,16 @@ def processor() -> SyncThreadProcessor:
     proc._art = MagicMock()  # noqa: SLF001
     proc._last_used = time.monotonic()  # noqa: SLF001
     return proc
+
+
+@pytest.fixture(autouse=True)
+def _tv_watch_mode_off(monkeypatch) -> None:  # noqa: ANN001
+    """Turn TV watch mode off by default; the watch-mode tests override it."""
+    monkeypatch.setattr(base, "read_bool_setting", lambda *_, **__: False)
+
+
+def _enable_tv_watch_mode(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setattr(base, "read_bool_setting", lambda *_, **__: True)
 
 
 # --- gating ---
@@ -46,6 +57,51 @@ def test_unknown_after_a_failed_query_is_permissive(processor: SyncThreadProcess
     processor.note_art_mode(active=False)
     processor.note_art_mode(active=None)
     assert processor.art_mode_permits_upload() is True
+
+
+# --- TV watch mode ---
+
+
+def test_tv_watch_mode_blocks_uploads_even_in_art_mode(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """
+    TV watch mode is a hard stop, independent of what art mode reports.
+
+    Checked before the art-mode state precisely so the toggle does not depend on
+    detection being accurate or up to date.
+    """
+    processor.note_art_mode(active=True)
+    _enable_tv_watch_mode(monkeypatch)
+
+    assert processor.art_mode_permits_upload() is False
+
+
+def test_tv_watch_mode_blocks_uploads_when_state_is_unknown(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """The usual permissive fallback for an unknown state does not override the toggle."""
+    processor.note_art_mode(active=None)
+    _enable_tv_watch_mode(monkeypatch)
+
+    assert processor.art_mode_permits_upload() is False
+
+
+@pytest.mark.asyncio
+async def test_tv_watch_mode_suppresses_the_post_write_restore(
+    processor: SyncThreadProcessor,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """
+    Art mode is not restored while watching, even though we know we caused the drop.
+
+    This is the one place the app would otherwise be certain it should intervene; the
+    toggle deliberately outranks that certainty.
+    """
+    processor.get_art_mode = AsyncMock(return_value=False)
+    processor.set_art_mode = AsyncMock(return_value=True)
+    _enable_tv_watch_mode(monkeypatch)
+
+    await processor.verify_art_mode_after_write()
+
+    processor.set_art_mode.assert_not_awaited()
+    assert processor.art_mode_active is False
 
 
 # --- post-write verification ---

--- a/tests/unit/framegallery/frame_connector/processors/test_art_mode.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_art_mode.py
@@ -1,0 +1,172 @@
+"""Tests for the shared art-mode helpers on UploadProcessor."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from framegallery.frame_connector.processors.sync_thread import SyncThreadProcessor
+
+
+@pytest.fixture
+def processor() -> SyncThreadProcessor:
+    """Return a connected SyncThreadProcessor with a mocked sync art client."""
+    with patch("framegallery.frame_connector.processors.base.asyncio.create_task"):
+        proc = SyncThreadProcessor("192.168.1.100", 8002)
+    proc._connected = True  # noqa: SLF001
+    proc._tv_is_online = True  # noqa: SLF001
+    proc._art = MagicMock()  # noqa: SLF001
+    proc._last_used = time.monotonic()  # noqa: SLF001
+    return proc
+
+
+# --- gating ---
+
+
+def test_upload_permitted_before_anything_is_known(processor: SyncThreadProcessor) -> None:
+    """An unknown art-mode state stays permissive, so a watchdog problem can't freeze the slideshow."""
+    assert processor.art_mode_active is None
+    assert processor.art_mode_permits_upload() is True
+
+
+def test_upload_permitted_when_art_mode_is_on(processor: SyncThreadProcessor) -> None:
+    """The normal case."""
+    processor.note_art_mode(active=True)
+    assert processor.art_mode_permits_upload() is True
+
+
+def test_upload_suppressed_only_by_a_confident_off(processor: SyncThreadProcessor) -> None:
+    """Only a known "off" suppresses the push; uploads are invisible on regular TV."""
+    processor.note_art_mode(active=False)
+    assert processor.art_mode_permits_upload() is False
+
+
+def test_unknown_after_a_failed_query_is_permissive(processor: SyncThreadProcessor) -> None:
+    """A failed query reverts to permissive rather than latching the last "off"."""
+    processor.note_art_mode(active=False)
+    processor.note_art_mode(active=None)
+    assert processor.art_mode_permits_upload() is True
+
+
+# --- post-write verification ---
+
+
+@pytest.mark.asyncio
+async def test_no_restore_when_art_mode_survived(processor: SyncThreadProcessor) -> None:
+    """The common case: our writes did not knock the TV out of art mode."""
+    processor.get_art_mode = AsyncMock(return_value=True)
+    processor.set_art_mode = AsyncMock(return_value=True)
+
+    await processor.verify_art_mode_after_write()
+
+    processor.set_art_mode.assert_not_awaited()
+    assert processor.art_mode_active is True
+
+
+@pytest.mark.asyncio
+async def test_restore_when_art_mode_dropped_during_our_writes(processor: SyncThreadProcessor) -> None:
+    """
+    Art mode off immediately after our command sequence means we caused it.
+
+    This is the only path allowed to force art mode back on.
+    """
+    processor.get_art_mode = AsyncMock(side_effect=[False, True])
+    processor.set_art_mode = AsyncMock(return_value=True)
+
+    await processor.verify_art_mode_after_write()
+
+    processor.set_art_mode.assert_awaited_once_with(enabled=True)
+    assert processor.art_mode_active is True
+
+
+@pytest.mark.asyncio
+async def test_no_restore_attempt_when_state_is_unknown(processor: SyncThreadProcessor) -> None:
+    """
+    An unanswerable query must not trigger a restore.
+
+    "Could not ask" usually means the art channel is wedged, and firing more commands
+    at a Frame in that state is what the settle delays exist to avoid.
+    """
+    processor.get_art_mode = AsyncMock(return_value=None)
+    processor.set_art_mode = AsyncMock(return_value=True)
+
+    await processor.verify_art_mode_after_write()
+
+    processor.set_art_mode.assert_not_awaited()
+    assert processor.art_mode_active is None
+
+
+@pytest.mark.asyncio
+async def test_accepted_but_ineffective_restore_is_not_reported_as_success(
+    processor: SyncThreadProcessor,
+) -> None:
+    """
+    The TV accepting set_artmode is not the same as it acting on it.
+
+    A Frame wedged badly enough to ignore the command must not be left recorded as
+    being in art mode, or the slideshow would resume pushing into regular TV.
+    """
+    processor.get_art_mode = AsyncMock(side_effect=[False, False])
+    processor.set_art_mode = AsyncMock(return_value=True)
+
+    await processor.verify_art_mode_after_write()
+
+    processor.set_art_mode.assert_awaited_once_with(enabled=True)
+    assert processor.art_mode_active is False
+
+
+@pytest.mark.asyncio
+async def test_failed_restore_command_leaves_state_off(processor: SyncThreadProcessor) -> None:
+    """When the command itself fails there is nothing to re-query."""
+    processor.get_art_mode = AsyncMock(return_value=False)
+    processor.set_art_mode = AsyncMock(return_value=False)
+
+    await processor.verify_art_mode_after_write()
+
+    assert processor.art_mode_active is False
+    assert processor.get_art_mode.await_count == 1
+
+
+# --- sync_thread's art-mode queries ---
+
+
+@pytest.mark.asyncio
+async def test_get_art_mode_maps_on_to_true(processor: SyncThreadProcessor) -> None:
+    """The TV reports art mode as the string "on"/"off"."""
+    processor._run_tv_op = AsyncMock(return_value="on")  # noqa: SLF001
+    assert await processor.get_art_mode() is True
+
+    processor._run_tv_op = AsyncMock(return_value="off")  # noqa: SLF001
+    assert await processor.get_art_mode() is False
+
+
+@pytest.mark.asyncio
+async def test_exhausted_retries_report_unknown_not_off(processor: SyncThreadProcessor) -> None:
+    """
+    _run_tv_op yields None when it gives up without raising.
+
+    That is "no answer", not "art mode is off" -- reporting False would gate the
+    slideshow off and trigger a spurious restore.
+    """
+    processor._run_tv_op = AsyncMock(return_value=None)  # noqa: SLF001
+
+    assert await processor.get_art_mode() is None
+
+
+@pytest.mark.asyncio
+async def test_query_failure_reports_unknown(processor: SyncThreadProcessor) -> None:
+    """A raising query is unknown, not off."""
+    processor._run_tv_op = AsyncMock(side_effect=OSError("socket gone"))  # noqa: SLF001
+
+    assert await processor.get_art_mode() is None
+
+
+@pytest.mark.asyncio
+async def test_art_mode_queries_are_skipped_while_disconnected(processor: SyncThreadProcessor) -> None:
+    """Without a connection there is nothing to ask, and nothing to command."""
+    processor._connected = False  # noqa: SLF001
+    processor._run_tv_op = AsyncMock()  # noqa: SLF001
+
+    assert await processor.get_art_mode() is None
+    assert await processor.set_art_mode(enabled=True) is False
+    processor._run_tv_op.assert_not_awaited()  # noqa: SLF001

--- a/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
@@ -165,9 +165,10 @@ async def test_apply_active_image_uploads_activates_deletes(processor: SyncThrea
     assert any(d.startswith("select MY-F0009") for d in calls)
     assert any(d.startswith("delete MY-OLD") for d in calls)
     assert processor._latest_content_id == "MY-F0009"  # noqa: SLF001
-    # The TV settles between commands: once before select, once before delete.
-    settles_before_select_and_delete = 2
-    assert processor._settle.await_count == settles_before_select_and_delete  # noqa: SLF001
+    # The TV settles between commands: before select, before delete, and once more
+    # before the post-write art-mode check.
+    settles_before_select_delete_and_verify = 3
+    assert processor._settle.await_count == settles_before_select_delete_and_verify  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -189,8 +190,9 @@ async def test_apply_active_image_settles_before_switching(processor: SyncThread
 
     await processor.apply_active_image(photo)
 
-    # Upload happens, then the settle pause, then the switch.
-    assert events == ["upload", "settle", "select"]
+    # Upload happens, then the settle pause, then the switch. The trailing
+    # settle + get_artmode is the post-write art-mode verification.
+    assert events == ["upload", "settle", "select", "settle", "get_artmode"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
@@ -7,8 +7,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from framegallery.frame_connector.processors import sync_thread
+from framegallery.frame_connector.processors import base, sync_thread
 from framegallery.frame_connector.processors.sync_thread import SyncThreadProcessor
+
+
+@pytest.fixture(autouse=True)
+def _tv_watch_mode_off(monkeypatch) -> None:  # noqa: ANN001
+    """Answer the TV-watch-mode lookup without touching a real database."""
+    monkeypatch.setattr(base, "read_bool_setting", lambda *_, **__: False)
 
 
 @pytest.fixture

--- a/tests/unit/framegallery/frame_connector/test_art_mode_watchdog.py
+++ b/tests/unit/framegallery/frame_connector/test_art_mode_watchdog.py
@@ -1,0 +1,148 @@
+"""Unit tests for the art-mode watchdog."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from framegallery.frame_connector.art_mode_watchdog import ArtModeWatchdog, TvHealth
+
+
+def _processor(*, powered: bool | None, art_mode: bool | None = None) -> MagicMock:
+    """Build a processor stub whose two probes return the given readings."""
+    processor = MagicMock()
+    processor.is_tv_powered_on = AsyncMock(return_value=powered)
+    processor.get_art_mode = AsyncMock(return_value=art_mode)
+    processor.set_art_mode = AsyncMock(return_value=True)
+    processor.close = AsyncMock()
+    processor.note_art_mode = MagicMock()
+    return processor
+
+
+def _watchdog(processor: MagicMock) -> ArtModeWatchdog:
+    return ArtModeWatchdog(processor, poll_interval=60)
+
+
+@pytest.mark.asyncio
+async def test_art_on_when_powered_and_art_mode_active() -> None:
+    """The healthy case: REST says powered, the art channel says art mode is on."""
+    processor = _processor(powered=True, art_mode=True)
+
+    assert await _watchdog(processor).probe_once() is TvHealth.ART_ON
+    processor.note_art_mode.assert_called_once_with(active=True)
+
+
+@pytest.mark.asyncio
+async def test_tv_mode_when_art_mode_off() -> None:
+    """Powered with art mode off is TV_MODE, and gates the slideshow."""
+    processor = _processor(powered=True, art_mode=False)
+
+    assert await _watchdog(processor).probe_once() is TvHealth.TV_MODE
+    processor.note_art_mode.assert_called_once_with(active=False)
+
+
+@pytest.mark.asyncio
+async def test_standby_when_not_powered() -> None:
+    """A reachable but powered-down TV is STANDBY, and the art channel is not probed."""
+    processor = _processor(powered=False)
+
+    assert await _watchdog(processor).probe_once() is TvHealth.STANDBY
+    processor.get_art_mode.assert_not_awaited()
+    # Standby is not an art-mode reading, so it must not gate the slideshow.
+    processor.note_art_mode.assert_called_once_with(active=None)
+
+
+@pytest.mark.asyncio
+async def test_unreachable_when_rest_probe_fails() -> None:
+    """No REST answer at all means the whole TV is gone, not that art mode is off."""
+    processor = _processor(powered=None)
+
+    assert await _watchdog(processor).probe_once() is TvHealth.UNREACHABLE
+    processor.note_art_mode.assert_called_once_with(active=None)
+
+
+@pytest.mark.asyncio
+async def test_art_unavailable_when_rest_answers_but_art_channel_does_not() -> None:
+    """
+    REST up + art channel silent is the art-crash signature.
+
+    This is the distinction that ICMP alone cannot make, and the reason the watchdog
+    probes power state over REST separately from the art WebSocket.
+    """
+    processor = _processor(powered=True, art_mode=None)
+
+    assert await _watchdog(processor).probe_once() is TvHealth.ART_UNAVAILABLE
+    # "Could not ask" must not be recorded as a confident "off".
+    processor.note_art_mode.assert_called_once_with(active=None)
+
+
+@pytest.mark.asyncio
+async def test_watchdog_never_forces_art_mode_on() -> None:
+    """
+    The periodic probe must never restore art mode.
+
+    Between our own writes an "off" is indistinguishable from someone choosing to
+    watch television, so forcing it back on would fight the person holding the remote.
+    Restoring is done only by the post-write check, where causation is established.
+    """
+    processor = _processor(powered=True, art_mode=False)
+
+    await _watchdog(processor).probe_once()
+
+    processor.set_art_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connection_is_dropped_on_entering_a_bad_state() -> None:
+    """A wedged art channel does not heal itself, so the connection is torn down."""
+    processor = _processor(powered=True, art_mode=None)
+
+    await _watchdog(processor).probe_once()
+
+    processor.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connection_is_not_dropped_repeatedly_while_bad() -> None:
+    """
+    Recovery fires on the transition, not on every poll.
+
+    The reconnection pinger is already running while disconnected; closing on each
+    poll would fight it and spam the log for as long as the TV stays unreachable.
+    """
+    processor = _processor(powered=None)
+    watchdog = _watchdog(processor)
+
+    for _ in range(3):
+        await watchdog.probe_once()
+
+    processor.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovery_rearms_after_returning_to_health() -> None:
+    """Going bad, healthy, then bad again drops the connection on each fresh failure."""
+    processor = _processor(powered=None)
+    watchdog = _watchdog(processor)
+
+    await watchdog.probe_once()
+
+    processor.is_tv_powered_on.return_value = True
+    processor.get_art_mode.return_value = True
+    await watchdog.probe_once()
+    assert watchdog.health is TvHealth.ART_ON
+
+    processor.is_tv_powered_on.return_value = None
+    await watchdog.probe_once()
+
+    expected_drops = 2  # one per fresh entry into a bad state
+    assert processor.close.await_count == expected_drops
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_does_not_kill_the_state() -> None:
+    """A probe that raises propagates from probe_once (the loop is what swallows it)."""
+    processor = _processor(powered=True)
+    processor.is_tv_powered_on = AsyncMock(side_effect=OSError("boom"))
+
+    with pytest.raises(OSError, match="boom"):
+        await _watchdog(processor).probe_once()

--- a/tests/unit/framegallery/test_slideshow_gating.py
+++ b/tests/unit/framegallery/test_slideshow_gating.py
@@ -18,33 +18,71 @@ def test_batch_mode_never_pushes(monkeypatch) -> None:  # noqa: ANN001
         session_local.assert_not_called()
 
 
+def _repo(*, slideshow_enabled: bool = True, tv_watch_mode: bool = False) -> MagicMock:
+    """Build a ConfigRepository stub that answers per key rather than uniformly."""
+    values = {
+        ConfigKey.SLIDESHOW_ENABLED: slideshow_enabled,
+        ConfigKey.TV_WATCH_MODE_ENABLED: tv_watch_mode,
+    }
+    fake_repo = MagicMock()
+    fake_repo.get_bool.side_effect = lambda key, **_: values[key]
+    return fake_repo
+
+
 def test_single_async_honours_enabled_flag(monkeypatch) -> None:  # noqa: ANN001
     """In single_async mode the tick follows the SLIDESHOW_ENABLED config flag."""
     monkeypatch.setattr(main.settings, "upload_processor", "single_async")
-
-    fake_repo = MagicMock()
-    fake_repo.get_bool.return_value = True
+    fake_repo = _repo(slideshow_enabled=True)
 
     with (
         patch.object(main, "SessionLocal"),
         patch.object(main, "ConfigRepository", return_value=fake_repo),
     ):
         assert main._should_push_slideshow_tick() is True  # noqa: SLF001
-        fake_repo.get_bool.assert_called_once_with(ConfigKey.SLIDESHOW_ENABLED, default=True)
+
+    fake_repo.get_bool.assert_any_call(ConfigKey.SLIDESHOW_ENABLED, default=True)
 
 
 def test_single_async_disabled_skips(monkeypatch) -> None:  # noqa: ANN001
     """When SLIDESHOW_ENABLED is false, the tick is skipped."""
     monkeypatch.setattr(main.settings, "upload_processor", "single_async")
 
-    fake_repo = MagicMock()
-    fake_repo.get_bool.return_value = False
+    with (
+        patch.object(main, "SessionLocal"),
+        patch.object(main, "ConfigRepository", return_value=_repo(slideshow_enabled=False)),
+    ):
+        assert main._should_push_slideshow_tick() is False  # noqa: SLF001
+
+
+def test_tv_watch_mode_skips_the_whole_tick(monkeypatch) -> None:  # noqa: ANN001
+    """
+    TV watch mode stops the tick outright, even with the slideshow enabled.
+
+    Skipping the whole tick (rather than only the push) matters: advancing the
+    slideshow would keep rewriting the active image and emitting SSE updates for
+    pictures nobody is looking at, drifting the UI out of step with the screen.
+    """
+    monkeypatch.setattr(main.settings, "upload_processor", "single_async")
+
+    with (
+        patch.object(main, "SessionLocal"),
+        patch.object(main, "ConfigRepository", return_value=_repo(slideshow_enabled=True, tv_watch_mode=True)),
+    ):
+        assert main._should_push_slideshow_tick() is False  # noqa: SLF001
+
+
+def test_tv_watch_mode_is_checked_before_the_slideshow_flag(monkeypatch) -> None:  # noqa: ANN001
+    """The watch-mode veto short-circuits, so SLIDESHOW_ENABLED is not even consulted."""
+    monkeypatch.setattr(main.settings, "upload_processor", "single_async")
+    fake_repo = _repo(slideshow_enabled=True, tv_watch_mode=True)
 
     with (
         patch.object(main, "SessionLocal"),
         patch.object(main, "ConfigRepository", return_value=fake_repo),
     ):
-        assert main._should_push_slideshow_tick() is False  # noqa: SLF001
+        main._should_push_slideshow_tick()  # noqa: SLF001
+
+    fake_repo.get_bool.assert_called_once_with(ConfigKey.TV_WATCH_MODE_ENABLED, default=False)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/framegallery/test_status_endpoint.py
+++ b/tests/unit/framegallery/test_status_endpoint.py
@@ -1,0 +1,63 @@
+"""Tests for the /api/status endpoint's view of TV health."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from framegallery import main
+from framegallery.frame_connector.art_mode_watchdog import TvHealth
+
+
+def _install_state(monkeypatch, health: TvHealth | None, *, art_mode: bool | None) -> None:  # noqa: ANN001
+    """Point app.state at a stub watchdog/processor pair."""
+    watchdog = None if health is None else SimpleNamespace(health=health)
+    monkeypatch.setattr(main.app.state, "art_mode_watchdog", watchdog, raising=False)
+    monkeypatch.setattr(
+        main.app.state,
+        "upload_processor",
+        SimpleNamespace(art_mode_active=art_mode),
+        raising=False,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("health", "expected_tv_on"),
+    [
+        (TvHealth.ART_ON, True),
+        (TvHealth.TV_MODE, True),
+        (TvHealth.ART_UNAVAILABLE, True),
+        (TvHealth.STANDBY, False),
+        (TvHealth.UNREACHABLE, False),
+        (TvHealth.UNKNOWN, False),
+    ],
+)
+async def test_tv_on_reflects_health(monkeypatch, health: TvHealth, expected_tv_on: bool) -> None:  # noqa: ANN001, FBT001
+    """tv_on means "the TV is answering", which TV_MODE and a wedged art channel still are."""
+    _install_state(monkeypatch, health, art_mode=None)
+
+    assert (await main.status()).tv_on is expected_tv_on
+
+
+@pytest.mark.asyncio
+async def test_art_mode_is_reported_from_the_processor_cache(monkeypatch) -> None:  # noqa: ANN001
+    """The endpoint serves the cached reading rather than probing the TV per request."""
+    _install_state(monkeypatch, TvHealth.TV_MODE, art_mode=False)
+
+    assert (await main.status()).art_mode_active is False
+
+
+@pytest.mark.asyncio
+async def test_art_mode_unknown_when_watchdog_is_disabled(monkeypatch) -> None:  # noqa: ANN001
+    """
+    With no watchdog nothing observes the TV.
+
+    Reporting art_mode_active=True here (as the old stub did) would be inventing a
+    value the app has no way of knowing.
+    """
+    _install_state(monkeypatch, None, art_mode=None)
+
+    result = await main.status()
+
+    assert result.art_mode_active is None
+    assert result.tv_on is False

--- a/ui/src/models/Settings.ts
+++ b/ui/src/models/Settings.ts
@@ -8,4 +8,6 @@ export interface Settings {
   current_active_image_since: string | null;
   active_filter: Filter | null;
   auto_cleanup_enabled: boolean;
+  /** While true the app pushes no images and never restores art mode. */
+  tv_watch_mode_enabled: boolean;
 }

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -16,6 +16,7 @@ import {
   Settings as SettingsIcon,
   CleaningServices as CleaningServicesIcon,
   Info as InfoIcon,
+  Tv as TvIcon,
 } from '@mui/icons-material';
 import { useSettings } from '../SettingsContext';
 import axios from 'axios';
@@ -51,6 +52,35 @@ const Settings: React.FC = () => {
     } catch (err) {
       console.error('Failed to update auto-cleanup setting:', err);
       setError('Failed to update auto-cleanup setting. Please try again.');
+    } finally {
+      setUpdating(false);
+    }
+  }, [refreshSettings]);
+
+  /**
+   * Handle TV watch mode toggle change.
+   */
+  const handleTvWatchModeChange = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const enabled = event.target.checked;
+    setUpdating(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      await axios.post('/api/config/tv_watch_mode_enabled', {
+        value: enabled
+      });
+
+      await refreshSettings();
+
+      setSuccess(
+        enabled
+          ? 'TV watch mode enabled — the app will leave the TV alone'
+          : 'TV watch mode disabled — the slideshow will resume'
+      );
+    } catch (err) {
+      console.error('Failed to update TV watch mode setting:', err);
+      setError('Failed to update TV watch mode setting. Please try again.');
     } finally {
       setUpdating(false);
     }
@@ -114,6 +144,47 @@ const Settings: React.FC = () => {
             {success}
           </Alert>
         )}
+
+        {/* TV Watch Mode */}
+        <Paper elevation={2} sx={{ p: 3, mb: 3 }}>
+          <Stack direction="row" spacing={2} sx={{ alignItems: 'center', mb: 2 }}>
+            <TvIcon sx={{ fontSize: 24, color: 'primary.main' }} />
+            <Typography variant="h6" component="h2">
+              TV Watch Mode
+            </Typography>
+          </Stack>
+
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+            Turn this on when you want to watch television. The app stops pushing images to the TV
+            and will never switch it back to Art Mode, so it cannot interrupt you mid-programme.
+            Turn it off again and the slideshow picks up where it left off.
+          </Typography>
+
+          <FormControlLabel
+            control={
+              <Switch
+                checked={settings.tv_watch_mode_enabled}
+                onChange={handleTvWatchModeChange}
+                disabled={updating}
+              />
+            }
+            label={
+              <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                <Typography>
+                  I&apos;m watching TV — leave the TV alone
+                </Typography>
+                {updating && <CircularProgress size={16} />}
+              </Stack>
+            }
+          />
+
+          {settings.tv_watch_mode_enabled && (
+            <Alert severity="info" sx={{ mt: 2 }}>
+              The slideshow is paused and Art Mode will not be restored automatically, including
+              after an Art Mode crash. Switch this off when you are done watching.
+            </Alert>
+          )}
+        </Paper>
 
         {/* TV Auto-cleanup Settings */}
         <Paper elevation={2} sx={{ p: 3, mb: 3 }}>


### PR DESCRIPTION
## Context

Investigating the Frame crashing out of gallery mode showed the app had **no art-mode awareness at all** on the deployed configuration. `single_async` checked art mode before pushing (`single_async.py:95`), but `sync_thread` — the processor actually running — did not. Nothing detected that the TV had fallen back to regular TV, nothing recovered a wedged art channel, and `/api/status` returned hardcoded `True`s.

Observed logs showed both failure shapes: a wedged art channel with REST still answering, and sustained outages where REST itself failed and the TV then dropped off the network entirely for several minutes. The app never recovered from either on its own — every sustained outage ended only when the container was restarted.

This PR contains two commits: the watchdog, and a **TV Watch Mode** toggle that lets you override it.

---

# 1. Art-mode watchdog

## The core problem: you cannot tell why art mode is off

The Frame leaves art mode either because someone picked up the remote, or because the art system crashed. `get_artmode` reports `"off"` in both cases. **So this watchdog does not guess.**

I did consider correlating an art-mode drop against the timing of our own commands, but the numbers kill it: with `slideshow_interval=180s` a write happens every 3 minutes, so the average gap between a random human switch and our last write is ~90s. Any window wide enough to catch a crash would misclassify the majority of human switches. Rejected in favour of something exact.

**Art mode is only force-enabled immediately after our own writes** (`verify_art_mode_after_write`). Finding it off at that instant means we knocked the TV out of it, so restoring cannot be fighting someone who just reached for the remote. The periodic poll never restores.

Residual gap, deliberately accepted and documented: a spontaneous crash *between* writes is indistinguishable from a human, so the Frame stays on regular TV until you switch it back.

## What it does

- **Gates slideshow pushes** while art mode is off — uploads are invisible on regular TV, and issuing them is itself a common way to wedge the Frame. Resumes automatically when art mode returns.
- **Probes REST power state separately from the art WebSocket.** `/api/v2/` is a plain HTTP GET that still answers when the art channel has wedged. ICMP can't make that call, since a Frame in standby still replies to ping — which is why the existing pinger could believe the TV was "online" and push into a dead socket.
- **Rebuilds the connection** on entering a bad state, closing the gap where `_run_tv_op` failures left `_connected = True` and never re-armed the reconnection pinger.

| Health | Meaning |
|---|---|
| `art_on` | Reachable, displaying art |
| `tv_mode` | Reachable, art mode off |
| `standby` | Reachable, powered down |
| `art_unavailable` | REST answers, art channel does not — the crash signature |
| `unreachable` | No response at all |

## "Could not ask" is not "off"

Threaded throughout: a `None` reading never gates the slideshow and never triggers a restore. A watchdog or connection problem therefore cannot silently freeze the display, nor answer a wedged TV with more commands.

This caught a real bug while writing the tests: `_run_tv_op` returns `None` when it exhausts retries *without raising*, and `None == "on"` evaluates to a confident `False` — which would have gated the slideshow off and fired a spurious restore. Now special-cased.

Similarly, `set_artmode` being accepted is not the same as the TV acting on it, so the restore path re-queries and reports failure rather than assuming success.

---

# 2. TV Watch Mode toggle

A **Settings** page switch for when you want to watch television and be certain the app will not interfere. While on:

- **no images are pushed at all**, and
- **art mode is never restored** — including immediately after our own writes, the one case where the app would otherwise be confident it should intervene. The toggle deliberately outranks that certainty: someone mid-programme would rather keep watching than have the app claw the screen back.

The check sits **before** the art-mode state in `art_mode_permits_upload()`, so it does not depend on art-mode detection being accurate or up to date. That is the point of having it — the watchdog's reading can be stale or wrong, and the toggle should work regardless.

**Enforced at two levels:**

- `_should_push_slideshow_tick()` skips the tick *entirely* rather than merely suppressing the push. Advancing the slideshow would keep rewriting the active image and emitting SSE updates for pictures nobody is looking at, drifting the UI out of step with the screen.
- The processor gate then also covers paths that bypass the tick, notably `POST /api/images/next`.

Stored in the `config` table rather than as an environment variable so it can be toggled without a restart, and read live on every check via a new `read_bool_setting()` helper — background loops and the processors have no session injected and must not cache a value captured at startup. Also exposed at `GET`/`POST /api/config/tv_watch_mode_enabled`.

---

## Also

- `/api/status` now serves observed state instead of hardcoded `True`s, from the cached reading so polling it adds no load to a TV that is already struggling. With the watchdog disabled the art-mode fields report `null` rather than inventing a value.
- New settings: `art_mode_watchdog_enabled` (default `true`), `art_mode_poll_interval` (default `60`).
- `batch_slideshow` inherits the probes and connection recovery, but keeps its own `apply_active_image` and so has **no post-write verification**. Left alone deliberately — its upload semantics differ and I can't exercise that mode.

## Testing

- `uv run pytest` — **224 passed** (was 187); `ruff check` and `ruff format --check` clean
- UI: `eslint` clean, 40 Jest tests pass, `vite build` succeeds
- 27 new tests across the watchdog state machine, the post-write restore logic, the TV-watch-mode overrides, the slideshow gate, and the status endpoint
- Existing `sync_thread` and slideshow-gating tests updated where behaviour legitimately changed (post-write check adds a settle + `get_artmode`; the gate now reads two keys)
- Integration test confirms `read_bool_setting` opens its own session and observes committed values
- Smoke-tested against an unroutable IP (TEST-NET-1): classified `unreachable` in exactly 5.0s (the REST timeout), recorded art mode as unknown rather than off, and stayed fail-open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

