### PR TITLE
chore: hold typescript at v6 until tooling supports v7

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -16,6 +16,22 @@
       // Hold eslint and @eslint/js at v9 until eslint-plugin-react supports v10.
       "matchPackageNames": ["eslint", "@eslint/js"],
       "allowedVersions": "<10"
+    },
+    {
+      // TypeScript 7 is the Go rewrite, which did not carry over the compiler API
+      // that tooling uses to walk the AST and read type information; the replacement
+      // stable API is scheduled for 7.1. Both of this project's TypeScript consumers
+      // depend on that API: typescript-eslint refuses to load at all under TS 7
+      // ("typescript-eslint does not support TS 7.0"), so `npm run lint` exits 2, and
+      // ts-jest excludes it in its peer range (">=4.3 <7").
+      //
+      // Nothing here type-checks at build time either -- `npm run build` is `vite
+      // build`, and there is no typecheck script or tsc step in CI -- so v7's faster
+      // checking would gain us nothing today. Hold at v6 until typescript-eslint
+      // supports TS >=7.1, tracked at:
+      // https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
## Context

[#562](https://github.com/slknijnenburg/framegallery/pull/562) (`typescript` v6 → v7) fails CI, and it cannot be fixed from this side. This holds `typescript` at v6 so the upgrade stops being reproposed as a failing PR every week.

## Why it fails

TypeScript 7 is the Go rewrite. It did not carry over the compiler API that tooling uses to walk the AST and read type information — the replacement stable API is scheduled for **7.1**.

Both TypeScript consumers in this project depend on that API:

- **typescript-eslint** now refuses to load at all under TS 7. The actual CI output:
  ```
  typescript-eslint does not support TS 7.0.
  See also https://github.com/typescript-eslint/typescript-eslint/issues/10940
  for tracking typescript-eslint's support for TS >=7.1
  Error: typescript-eslint does not support TS 7.0.
  ##[error]Process completed with exit code 2.
  ```
  This is an explicit guard in `typescript-eslint/dist/index.js`, so `npm run lint` exits 2.
- **ts-jest** excludes v7 in its peer range (`">=4.3 <7"`).

There is no version to bump to. As of today the latest releases still exclude TS 7:

| Package | Latest | Peer range |
|---|---|---|
| `typescript-eslint` | 8.65.0 | `>=4.8.4 <6.1.0` |
| `ts-jest` | 29.4.12 | `>=4.3 <7` |

`typescript@next` is `7.1.0-dev.*`, consistent with support landing after 7.1 ships.

## Why there's nothing to gain yet either

TS 7's headline win is ~10× faster type checking. Nothing in this project type-checks:

- `npm run build` is `vite build`, which transpiles without type checking
- there is no `typecheck` script in `package.json`
- CI (`quality-js.yml`) runs only `npm install`, `npm run lint`, `npm test` — no `tsc` step

So the only consumers of TypeScript here are typescript-eslint, ts-jest, and the editor. Adopting v7 today would mean carrying the dual-TypeScript workaround (v7 for `tsc`, v6 pinned for ESLint via `@typescript/typescript6`) in exchange for no measurable benefit, while lint and tests stay broken.

Worth noting the tsconfig is already TS7-shaped and needs no work when the time comes: `target: ESNext`, `moduleResolution: bundler`, `strict: true`, explicit `rootDir` and `types`, no `baseUrl`.

## Change

One `packageRules` entry holding `typescript` at `<7`, following the existing `eslint` v9 hold which exists for the same class of reason (a peer-range incompatibility that breaks the build).

Revisit when typescript-eslint supports TS >=7.1 — [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940).

## Testing

Config parses and both rules resolve as intended:

```
[{"matchPackageNames":["eslint","@eslint/js"],"allowedVersions":"<10"},
 {"matchPackageNames":["typescript"],"allowedVersions":"<7"}]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
