### PR TITLE
fix: TV Files page failed with "URL constructor: is not a valid URL"

### DIFF
--- a/ui/src/services/tvFilesService.ts
+++ b/ui/src/services/tvFilesService.ts
@@ -1,15 +1,20 @@
 import { API_BASE_URL } from '../App';
 import { TvFile, TvCategory, TV_CATEGORIES } from '../models/TvFile';
 
-// Helper function to detect development mode
-const isDevelopmentMode = () => {
-  // Check for Jest environment (when window might not exist)
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  // Check hostname for development - covers both Vite dev server and general localhost usage
-  return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+/**
+ * Build an absolute-path API URL.
+ *
+ * Requests go to a path relative to whatever origin is serving the app: in
+ * production the backend serves the UI itself, and in development the Vite dev
+ * server proxies /api through to it (see vite.config.ts). So there is no need to
+ * know the backend's host, and no need to branch on the environment.
+ *
+ * Note this deliberately does not use `new URL(path, API_BASE_URL)`: API_BASE_URL
+ * is the empty string, which is not a valid base and makes that constructor throw.
+ */
+const apiUrl = (path: string, params?: Record<string, string>): string => {
+  const query = params ? `?${new URLSearchParams(params)}` : '';
+  return `${API_BASE_URL}${path}${query}`;
 };
 
 /**
@@ -48,13 +53,7 @@ export const tvFilesService = {
    */
   async getTvFiles(category: TvCategory = TV_CATEGORIES.USER_CONTENT): Promise<TvFile[]> {
     try {
-      // Use direct backend URL in development, relative URL in production
-      const isDevelopment = isDevelopmentMode();
-      const baseUrl = isDevelopment ? 'http://localhost:7999' : API_BASE_URL;
-      const url = new URL('/api/tv/files', baseUrl);
-      url.searchParams.set('category', category);
-
-      const response = await fetch(url.toString());
+      const response = await fetch(apiUrl('/api/tv/files', { category }));
 
       if (!response.ok) {
         // Handle specific error cases
@@ -201,12 +200,7 @@ export const tvFilesService = {
    */
   async deleteTvFile(contentId: string): Promise<void> {
     try {
-      // Use direct backend URL in development, relative URL in production
-      const isDevelopment = isDevelopmentMode();
-      const baseUrl = isDevelopment ? 'http://localhost:7999' : API_BASE_URL;
-      const url = new URL(`/api/tv/files/${encodeURIComponent(contentId)}`, baseUrl);
-
-      const response = await fetch(url.toString(), {
+      const response = await fetch(apiUrl(`/api/tv/files/${encodeURIComponent(contentId)}`), {
         method: 'DELETE',
       });
 
@@ -278,12 +272,7 @@ export const tvFilesService = {
     }
 
     try {
-      // Use direct backend URL in development, relative URL in production
-      const isDevelopment = isDevelopmentMode();
-      const baseUrl = isDevelopment ? 'http://localhost:7999' : API_BASE_URL;
-      const url = new URL('/api/tv/files/delete', baseUrl);
-
-      const response = await fetch(url.toString(), {
+      const response = await fetch(apiUrl('/api/tv/files/delete'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/ui/tests/services/tvFilesService.test.ts
+++ b/ui/tests/services/tvFilesService.test.ts
@@ -8,7 +8,7 @@ global.fetch = mockFetch;
 
 describe('tvFilesService', () => {
   beforeEach(() => {
-    mockFetch.mockClear();
+    mockFetch.mockReset();
   });
 
   afterEach(() => {
@@ -16,7 +16,7 @@ describe('tvFilesService', () => {
   });
 
   describe('getTvFiles', () => {
-    it.skip('should fetch TV files successfully', async () => {
+    it('should fetch TV files successfully', async () => {
       const mockFiles = [
         {
           content_id: 'MY-F0001',
@@ -36,7 +36,7 @@ describe('tvFilesService', () => {
         statusText: 'OK',
         json: jest.fn().mockResolvedValue(mockFiles),
       };
-      mockFetch.mockResolvedValueOnce(mockResponse as Response);
+      mockFetch.mockResolvedValue(mockResponse as Response);
 
       const result = await tvFilesService.getTvFiles();
 
@@ -46,7 +46,7 @@ describe('tvFilesService', () => {
       );
     });
 
-    it.skip('should handle custom category parameter', async () => {
+    it('should handle custom category parameter', async () => {
       const mockFiles = [];
 
       const mockResponse = {
@@ -55,7 +55,7 @@ describe('tvFilesService', () => {
         statusText: 'OK',
         json: jest.fn().mockResolvedValue(mockFiles),
       };
-      mockFetch.mockResolvedValueOnce(mockResponse as Response);
+      mockFetch.mockResolvedValue(mockResponse as Response);
 
       await tvFilesService.getTvFiles(TV_CATEGORIES.ART_STORE);
 
@@ -64,8 +64,8 @@ describe('tvFilesService', () => {
       );
     });
 
-    it.skip('should throw TvServiceError for 503 status (TV unavailable)', async () => {
-      mockFetch.mockResolvedValueOnce({
+    it('should throw TvServiceError for 503 status (TV unavailable)', async () => {
+      mockFetch.mockResolvedValue({
         ok: false,
         status: 503,
         statusText: 'Service Unavailable',
@@ -86,8 +86,8 @@ describe('tvFilesService', () => {
       }
     });
 
-    it.skip('should throw TvServiceError for 500 status (server error)', async () => {
-      mockFetch.mockResolvedValueOnce({
+    it('should throw TvServiceError for 500 status (server error)', async () => {
+      mockFetch.mockResolvedValue({
         ok: false,
         status: 500,
         statusText: 'Internal Server Error',
@@ -108,8 +108,8 @@ describe('tvFilesService', () => {
       }
     });
 
-    it.skip('should throw TvServiceError for other HTTP errors', async () => {
-      mockFetch.mockResolvedValueOnce({
+    it('should throw TvServiceError for other HTTP errors', async () => {
+      mockFetch.mockResolvedValue({
         ok: false,
         status: 404,
         statusText: 'Not Found',
@@ -129,8 +129,8 @@ describe('tvFilesService', () => {
       }
     });
 
-    it.skip('should handle network errors', async () => {
-      mockFetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+    it('should handle network errors', async () => {
+      mockFetch.mockRejectedValue(new TypeError('fetch failed'));
 
       await expect(tvFilesService.getTvFiles()).rejects.toThrow(TvServiceError);
 
@@ -144,8 +144,8 @@ describe('tvFilesService', () => {
       }
     });
 
-    it.skip('should handle unexpected errors', async () => {
-      mockFetch.mockRejectedValueOnce(new Error('Unexpected error'));
+    it('should handle unexpected errors', async () => {
+      mockFetch.mockRejectedValue(new Error('Unexpected error'));
 
       await expect(tvFilesService.getTvFiles()).rejects.toThrow(TvServiceError);
 
@@ -180,12 +180,12 @@ describe('tvFilesService', () => {
       expect(tvFilesService.formatFileSize(1536)).toBe('1.5 KB');
     });
 
-    it.skip('should handle null values', () => {
+    it('should handle null values', () => {
       expect(tvFilesService.formatFileSize(null)).toBe('Unknown');
       expect(tvFilesService.formatFileSize(undefined as unknown as number | null)).toBe('Unknown');
     });
 
-    it.skip('should handle very large files', () => {
+    it('should handle very large files', () => {
       expect(tvFilesService.formatFileSize(5 * 1024 * 1024 * 1024)).toBe('5.0 GB');
     });
   });
@@ -198,16 +198,59 @@ describe('tvFilesService', () => {
       expect(result).toMatch(/Jan|15/);
     });
 
-    it.skip('should handle null dates', () => {
+    it('should handle null dates', () => {
       expect(tvFilesService.formatDate(null)).toBe('Unknown');
     });
 
-    it.skip('should handle invalid dates', () => {
+    it('should handle invalid dates', () => {
       expect(tvFilesService.formatDate('invalid-date')).toBe('Invalid Date');
     });
 
-    it.skip('should handle empty strings', () => {
+    it('should handle empty strings', () => {
       expect(tvFilesService.formatDate('')).toBe('Unknown');
+    });
+  });
+
+  describe('request URLs', () => {
+    /**
+     * These pin the fix for "URL constructor: is not a valid URL".
+     *
+     * The service used to build requests with `new URL(path, base)`, where base was
+     * API_BASE_URL ('') anywhere other than localhost. An empty string is not a valid
+     * base URL, so the constructor threw before any request was made -- meaning the
+     * TV Files page failed for every real deployment while working on a dev machine.
+     */
+    const okResponse = () =>
+      ({ ok: true, status: 200, statusText: 'OK', json: jest.fn().mockResolvedValue([]) }) as unknown as Response;
+
+    it('requests a relative path rather than a hardcoded origin', async () => {
+      mockFetch.mockResolvedValue(okResponse());
+
+      await tvFilesService.getTvFiles();
+
+      const requested = mockFetch.mock.calls[0][0] as string;
+      expect(requested.startsWith('/api/tv/files')).toBe(true);
+      expect(requested).not.toContain('localhost');
+      expect(requested).not.toContain('http');
+    });
+
+    it('encodes the category as a query parameter', async () => {
+      mockFetch.mockResolvedValue(okResponse());
+
+      await tvFilesService.getTvFiles(TV_CATEGORIES.ART_STORE);
+
+      expect(mockFetch.mock.calls[0][0]).toBe('/api/tv/files?category=MY-C0001');
+    });
+
+    it('builds relative paths for the delete endpoints too', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 204, statusText: 'No Content' } as Response);
+      await tvFilesService.deleteTvFile('MY-F0001');
+      expect(mockFetch.mock.calls[0][0]).toBe('/api/tv/files/MY-F0001');
+
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(okResponse());
+      await tvFilesService.deleteTvFiles(['MY-F0001']);
+      expect(mockFetch.mock.calls[0][0]).toBe('/api/tv/files/delete');
     });
   });
 });


### PR DESCRIPTION
## Symptom

The **Files on TV** page fails with:

> Unexpected error while fetching TV files: URL constructor: is not a valid URL.

## Cause

`tvFilesService` built every request with `new URL(path, base)`:

```ts
const baseUrl = isDevelopment ? 'http://localhost:7999' : API_BASE_URL;
const url = new URL('/api/tv/files', baseUrl);
```

`API_BASE_URL` is `''` (App.tsx:26), and an empty string is not a valid base URL:

```
new URL('/api/tv/files', '')                       -> TypeError: Invalid URL
new URL('/api/tv/files', 'http://localhost:7999')  -> works
```

So the constructor threw before any request was made — which is why **nothing appears in the backend log for `/api/tv/files`**; the request never left the browser.

`isDevelopmentMode()` keys off `window.location.hostname === 'localhost'`, so this affected every deployment not accessed over localhost while working perfectly on a dev machine. It hit all three endpoints: listing, single delete, and multi-delete — so the delete buttons on that page were broken too.

## Fix

Dropped the environment branching and switched to relative paths. The backend serves the UI in production, and the Vite dev server proxies `/api` through to it (`vite.config.ts`), so the app never needs to know the backend's host. Query strings go through `URLSearchParams`.

```ts
const apiUrl = (path: string, params?: Record<string, string>): string => {
  const query = params ? `?${new URLSearchParams(params)}` : '';
  return `${API_BASE_URL}${path}${query}`;
};
```

This removes the failure mode rather than patching it — there's no longer a base URL to be invalid.

## Why the tests missed it

Two independent reasons:

1. **All seven `getTvFiles` tests were `it.skip`** — the network path was never exercised at all.
2. **jsdom serves from `http://localhost/`**, so even unskipped they'd have taken the dev branch and never built a URL the way production does.

Both are addressed. The tests are unskipped, and three new cases assert the requested URLs are relative and carry no hardcoded origin. I verified these **fail against the old code** before keeping them.

## A pre-existing test defect this surfaced

Unskipping revealed why they were probably disabled — four were genuinely broken. Each set a `mockResolvedValueOnce` but invoked the service **twice** (once for `rejects.toThrow`, once to inspect the error), so the second call got `undefined` and threw `Cannot read properties of undefined (reading 'ok')` instead of the 503/500/404/network error under test.

The mocks now persist for the duration of each test, with `mockReset()` in `beforeEach` so they can't leak between tests. (`mockClear()` only clears call records, not implementations.)

## Testing

- **55 tests passing, 0 skipped** (was 40 passing / 12 skipped)
- `eslint` clean, `vite build` succeeds
- Regression tests confirmed to fail against the pre-fix code

## Not changed

`App.tsx` has a similar dev/prod branch for the SSE endpoint, but it uses string concatenation rather than `new URL`, so `''` degrades to a working relative path. It also documents a specific reason for bypassing the proxy for SSE, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
