### PR TITLE
fix: check art mode after a failed upload, not just a successful one

### DIFF
--- a/framegallery/frame_connector/processors/single_async.py
+++ b/framegallery/frame_connector/processors/single_async.py
@@ -131,23 +131,37 @@ class SingleAsyncProcessor(UploadProcessor):
         """
         return await self.get_art_mode() is not False
 
-    async def apply_active_image(self, photo: PhotoRef) -> None:  # noqa: PLR0911
+    async def apply_active_image(self, photo: PhotoRef) -> None:
         """Upload the given photo to the TV, activate it, and delete the previous one."""
         logger.info("Updating active image on TV (via slideshow signal): %s", photo.composite_id)
 
-        # Upload the image to the TV
+        if not self._connected or not self._tv_is_online:
+            return
+
+        if not await self._is_art_mode_active():
+            logger.debug("TV is not in art-mode, skipping image update.")
+            return
+
+        logger.debug("apply_active_image: TV connected, uploading image")
+        photo_bytes = await self._fetch_photo_bytes(photo)
+        if photo_bytes is None:
+            # Nothing has touched the TV yet, so there is no art mode to re-check.
+            return
+
         try:
-            if not self._connected or not self._tv_is_online:
-                return
+            await self._push_to_tv(photo, photo_bytes)
+        finally:
+            # Everything in _push_to_tv touches the TV, so the art-mode check has to
+            # run on *every* exit path -- including a failed upload, which is the
+            # strongest signal available that we just knocked the Frame out of art
+            # mode. This previously sat at the end of the happy path, so an upload
+            # that failed returned early and skipped it.
+            await self._settle()
+            await self.verify_art_mode_after_write()
 
-            if not await self._is_art_mode_active():
-                logger.debug("TV is not in art-mode, skipping image update.")
-                return
-
-            logger.debug("apply_active_image: TV connected, uploading image")
-            photo_bytes = await self._fetch_photo_bytes(photo)
-            if photo_bytes is None:
-                return
+    async def _push_to_tv(self, photo: PhotoRef, photo_bytes: PhotoBytes) -> None:
+        """Upload the photo, activate it, and clear out previously uploaded images."""
+        try:
             data = await self._upload_photo(photo, photo_bytes)
         except websockets.exceptions.ConnectionClosedError:
             logger.exception("Connection to TV is closed, perhaps the TV is off?")
@@ -159,7 +173,6 @@ class SingleAsyncProcessor(UploadProcessor):
                 await self.reconnect()
             except TvNotConnectedError:
                 logger.exception("TV not connected, cannot update active image.")
-                return
             return
         except Exception:
             # log as much info about the error as possible
@@ -181,11 +194,6 @@ class SingleAsyncProcessor(UploadProcessor):
             logger.error("Slideshow image upload completed but did not return a content_id.")
         else:
             logger.error("Slideshow image upload failed, data is None.")
-
-        # Confirm the Frame is still in art mode after our command sequence: crashing
-        # out of it is exactly what this sequence provokes.
-        await self._settle()
-        await self.verify_art_mode_after_write()
 
     async def _upload_photo(self, photo: PhotoRef, photo_bytes: PhotoBytes) -> dict | None:
         """Upload photo bytes to TV and return the uploaded file details as provided by the television."""

--- a/framegallery/frame_connector/processors/sync_thread.py
+++ b/framegallery/frame_connector/processors/sync_thread.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
     from samsungtvws.art import SamsungTVArt
 
-    from framegallery.libraries.base import PhotoRef
+    from framegallery.libraries.base import PhotoBytes, PhotoRef
 
 logger = setup_logging(
     log_level=settings.log_level,
@@ -214,7 +214,24 @@ class SyncThreadProcessor(UploadProcessor):
 
         photo_bytes = await self._fetch_photo_bytes(photo)
         if photo_bytes is None:
+            # Nothing has touched the TV yet, so there is no art mode to re-check.
             return
+
+        try:
+            await self._push_to_tv(photo, photo_bytes)
+        finally:
+            # Everything in _push_to_tv touches the TV, so the art-mode check has to
+            # run on *every* exit path -- including a failed upload, which is the
+            # strongest signal available that we just knocked the Frame out of art
+            # mode. This previously sat at the end of the happy path, so an upload
+            # that failed returned early and skipped it, discarding the one piece of
+            # evidence that would have let us restore art mode instead of mistaking
+            # it for someone reaching for the remote.
+            await self._settle()
+            await self.verify_art_mode_after_write()
+
+    async def _push_to_tv(self, photo: PhotoRef, photo_bytes: PhotoBytes) -> None:
+        """Upload the photo, activate it, and clear out previously uploaded images."""
         matte = self._compute_matte(photo_bytes)
         file_data = photo_bytes.data
         file_type = photo_bytes.file_type_suffix
@@ -262,12 +279,6 @@ class SyncThreadProcessor(UploadProcessor):
             await self.drain_pending_deletions()
         except Exception:
             logger.exception("sync_thread: deleting previous TV images failed")
-
-        # Whether or not the sequence above succeeded, confirm the Frame is still in
-        # art mode: crashing out of it is exactly the failure this sequence provokes,
-        # and a failed select/delete makes that *more* likely, not less.
-        await self._settle()
-        await self.verify_art_mode_after_write()
 
     async def get_active_item_details(self) -> dict | None:
         """Get the current active item details from the TV."""

--- a/tests/unit/framegallery/frame_connector/processors/test_art_mode.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_art_mode.py
@@ -229,3 +229,114 @@ async def test_art_mode_queries_are_skipped_while_disconnected(processor: SyncTh
     assert await processor.get_art_mode() is None
     assert await processor.set_art_mode(enabled=True) is False
     processor._run_tv_op.assert_not_awaited()  # noqa: SLF001
+
+
+# --- the art-mode check must survive every failure path ---
+#
+# A Frame that dies mid-upload closes the WebSocket abruptly ("Invalid close opcode
+# 1005") and reappears moments later in regular TV mode. That failed upload is the
+# strongest evidence available that *we* caused the drop -- the one condition under
+# which restoring art mode is unambiguously right. apply_active_image used to return
+# early on it, skipping the check entirely, so the Frame sat on regular TV until
+# someone noticed.
+
+
+async def _apply(processor: SyncThreadProcessor, *, upload: object) -> MagicMock:
+    """Drive apply_active_image with a stubbed TV; return the verification spy."""
+    processor._fetch_photo_bytes = AsyncMock(  # noqa: SLF001
+        return_value=MagicMock(data=b"x", file_type_suffix="jpg", width=1920, height=1080)
+    )
+    processor._settle = AsyncMock()  # noqa: SLF001
+    verify = AsyncMock()
+    processor.verify_art_mode_after_write = verify
+
+    async def fake_run(fn, *, description, timeout, max_attempts=None):  # noqa: ANN001, ANN202, ARG001, ASYNC109
+        if description.startswith("upload"):
+            if isinstance(upload, Exception):
+                raise upload
+            return upload
+        return None
+
+    processor._run_tv_op = fake_run  # noqa: SLF001
+    processor.delete_files = AsyncMock(return_value={})
+    await processor.apply_active_image(MagicMock(composite_id="local:1"))
+    return verify
+
+
+@pytest.mark.asyncio
+async def test_art_mode_is_checked_after_a_failed_upload(processor: SyncThreadProcessor) -> None:
+    """A raising upload -- the Frame slamming the socket shut -- still triggers the check."""
+    verify = await _apply(processor, upload=OSError("Invalid close opcode 1005"))
+
+    verify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_art_mode_is_checked_when_upload_returns_no_content_id(processor: SyncThreadProcessor) -> None:
+    """An upload that yields nothing may still have reached the TV."""
+    verify = await _apply(processor, upload=None)
+
+    verify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_art_mode_is_checked_after_a_successful_upload(processor: SyncThreadProcessor) -> None:
+    """The happy path keeps checking, as before."""
+    verify = await _apply(processor, upload="MY-NEW")
+
+    verify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_check_when_the_photo_could_not_be_fetched(processor: SyncThreadProcessor) -> None:
+    """Failing before any TV call means there is nothing to re-check."""
+    processor._fetch_photo_bytes = AsyncMock(return_value=None)  # noqa: SLF001
+    processor._settle = AsyncMock()  # noqa: SLF001
+    processor.verify_art_mode_after_write = AsyncMock()
+
+    await processor.apply_active_image(MagicMock(composite_id="local:1"))
+
+    processor.verify_art_mode_after_write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_check_when_the_push_was_gated_off(processor: SyncThreadProcessor) -> None:
+    """A push suppressed because art mode is already off must not re-check or restore."""
+    processor.note_art_mode(active=False)
+    processor._settle = AsyncMock()  # noqa: SLF001
+    processor.verify_art_mode_after_write = AsyncMock()
+    processor._fetch_photo_bytes = AsyncMock()  # noqa: SLF001
+
+    await processor.apply_active_image(MagicMock(composite_id="local:1"))
+
+    processor.verify_art_mode_after_write.assert_not_awaited()
+    processor._fetch_photo_bytes.assert_not_awaited()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_failed_upload_restores_art_mode_when_the_tv_dropped_out(processor: SyncThreadProcessor) -> None:
+    """
+    End to end: the exact sequence observed in production.
+
+    Upload dies with the TV closing the socket, art mode reads back "off", and the
+    restore fires -- rather than the drop being left for the periodic watchdog, which
+    cannot distinguish it from someone reaching for the remote and so leaves it alone.
+    """
+    processor._fetch_photo_bytes = AsyncMock(  # noqa: SLF001
+        return_value=MagicMock(data=b"x", file_type_suffix="jpg", width=1920, height=1080)
+    )
+    processor._settle = AsyncMock()  # noqa: SLF001
+    processor.get_art_mode = AsyncMock(side_effect=[False, True])
+    processor.set_art_mode = AsyncMock(return_value=True)
+
+    async def fake_run(fn, *, description, timeout, max_attempts=None):  # noqa: ANN001, ANN202, ARG001, ASYNC109
+        if description.startswith("upload"):
+            msg = "Invalid close opcode 1005"
+            raise OSError(msg)
+
+    processor._run_tv_op = fake_run  # noqa: SLF001
+
+    await processor.apply_active_image(MagicMock(composite_id="local:1"))
+
+    processor.set_art_mode.assert_awaited_once_with(enabled=True)
+    assert processor.art_mode_active is True


### PR DESCRIPTION
## Context

The Frame was found sitting on regular TV for three hours. The logs show it was not a connectivity problem, and the watchdog behaved exactly as designed — the bug is that it never got the information it needed.

```
15:39:16  sync_thread: updating active image on TV: local:2112
15:39:17  upload failed (attempt 1/1): ('Invalid close opcode %r', 1005)
15:39:17  upload failed for local:2112
          <- verify_art_mode_after_write() never runs
15:39:57  TV is no longer in art mode (art_on -> tv_mode)
```

WebSocket close code **1005** is "no status received": the TV's art app slammed the socket shut mid-upload. Forty seconds later it was in TV mode. Our upload almost certainly caused it.

## The bug

`apply_active_image` returned early when the upload threw:

```python
except Exception:
    logger.exception("sync_thread: upload failed for %s", ...)
    return          # skips the post-write art-mode check entirely
```

The check sat at the bottom of the function, after select/delete. Its comment claimed *"Whether or not the sequence above succeeded"* — but that only covered select and delete. **A failed upload, the strongest signal the TV just crashed, skipped it completely.**

That matters because of how the two detection paths are meant to divide the work:

- The **post-write check** is the only path allowed to restore art mode, precisely because finding it off immediately after our own writes proves we caused it.
- The **periodic watchdog** deliberately never restores — between writes, an "off" is indistinguishable from someone reaching for the remote.

So the one case where causation was provable, we threw the evidence away. The watchdog then saw `tv_mode`, correctly assumed a human, and suppressed pushes. With pushes suppressed there are no further writes, so no further post-write checks — the Frame stays on regular TV indefinitely.

## Scale

From a single day's log:

| | |
|---|---|
| Upload attempts | 132 |
| Failed | **27 (20%)** |
| …with `Invalid close opcode 1005` | 23 |
| Post-write checks that ran | **0** |

Every one of those 27 was a missed chance to detect and restore.

## Fix

Everything that touches the TV moved into `_push_to_tv()`, with the art-mode check in a `finally` so no exit path can skip it:

```python
try:
    await self._push_to_tv(photo, photo_bytes)
finally:
    await self._settle()
    await self.verify_art_mode_after_write()
```

Fetching the photo still returns early *without* checking — nothing has reached the TV at that point, so there's no art mode to re-verify.

The check remains safe on the failure paths: it only restores on a confident `"off"`, and an unreachable TV reports `None`, which triggers nothing. On the observed failure the client had already dropped its connection, so the check reconnects and asks — exactly what the watchdog did 40s later, only sooner and with the authority to act.

Applied to `single_async` too, which had the same structure and the same gap.

## Testing

- **249 passed** (was 243); `ruff check` and `ruff format --check` clean; suite also verified against a nonexistent `db_url`
- 6 new tests covering each exit path: failed upload, no content_id, success, photo-fetch failure, gated-off push, plus an end-to-end reproduction of the production sequence (upload dies → art mode reads off → restore fires)
- The two central tests were **confirmed to fail against the pre-fix code** before being kept

## Note

This narrows the residual gap documented in #576 but does not close it. A spontaneous art-mode crash with no write in flight is still indistinguishable from someone watching TV, and is still left alone. What changes is that crashes *we* provoke — the large majority, given uploads are what destabilise the Frame — are now caught and recovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
