### PR TITLE
feat: support the plain-WebSocket TV port

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,6 +1,9 @@
 db_url="sqlite:///./data/framegallery.db"
 gallery_path="./images"
 tv_ip_address="192.168.2.76"
+# 8002 = TLS + token auth (one-time "Allow" prompt); 8001 = plain WebSockets, no
+# pairing. Try 8001 if uploads fail with WebSocket close code 1005 -- see the
+# "TV port" section of the README.
 tv_port=8002
 # Device name registered on the TV (granted the auth token). Keep it stable;
 # changing it makes the TV show a new "Allow" pairing prompt.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Create a `.env` file with your configuration. See `.env.dist` for all available 
 ```bash
 # Samsung TV Configuration
 tv_ip_address=192.168.1.100
-tv_port=8002
+tv_port=8002                  # 8002 = TLS + token auth; 8001 = plain WebSockets, no pairing. See "TV port" below
 tv_client_name=FrameGallery   # device name registered on the TV; keep stable to avoid re-pairing
 
 # Application Settings
@@ -180,6 +180,36 @@ Logs are written to two places, and both are capped so they cannot grow without 
 Note that the Docker-side limits only apply when the container is **recreated** (`docker compose up -d`); `docker compose restart` reuses the existing container and its current log settings.
 
 Running at `log_level=DEBUG` produces roughly 15k lines per day, the bulk of it HTTP client chatter from `httpcore`/`urllib3`. Set `log_level=INFO` to reduce this substantially; `websocket_log_level` remains a separate knob so the TV connection can still be debugged independently.
+
+#### TV port
+
+`tv_port` selects the whole transport, not just the port number. `samsungtvws` derives
+everything from it:
+
+| | `8002` (default) | `8001` |
+|---|---|---|
+| WebSocket | `wss://` | `ws://` |
+| Auth | token in the URL | none |
+| Pairing | one-time "Allow" prompt on the TV | not required, and skipped automatically |
+| REST probe | `https` | `http` |
+
+Both are served by current Frame firmware — 8001 is not a legacy-only option. Switching is
+a one-line change; the app detects that 8001 needs no token and skips pairing. Note that
+8001 is unencrypted and unauthenticated on your LAN.
+
+**Why you might switch.** Some Frames abort uploads by closing the WebSocket with status
+1005, which surfaces as:
+
+```
+sync_thread: TV op 'upload local:1234' failed: ('Invalid close opcode %r', 1005)
+```
+
+1005 is reserved by RFC 6455 and must never appear on the wire, so the TV is sending a
+malformed close frame. On at least one 2023 Frame (`QE32LS03CBUXXN`) these failures were
+frequent on 8002 and absent on 8001 across a same-window comparison, which suggests they
+relate to the token-authenticated channel rather than to uploading itself. The sample was
+small, so treat 8001 as an experiment worth measuring rather than a guaranteed fix: switch,
+then compare `grep -c "upload failed for" logs/framegallery.log` over a day.
 
 #### Database Migrations
 

--- a/framegallery/config.py
+++ b/framegallery/config.py
@@ -10,6 +10,11 @@ class Settings(BaseSettings):
 
     app_name: str = "Frame Gallery"
     tv_ip_address: str = "192.168.2.76"
+    # 8002 speaks TLS with token auth and requires a one-time "Allow" prompt on the
+    # TV; 8001 speaks plain WebSockets with no token and no pairing. The whole
+    # transport follows from this number -- ws:// vs wss://, http vs https for the
+    # REST probe, and whether pairing runs at all. Try 8001 if uploads fail with
+    # WebSocket close code 1005; see the "TV port" section of the README.
     tv_port: int = 8002
     # Client identity registered on the TV and granted the auth token. Must stay
     # constant across restarts; change it only if you want the TV to re-pair

--- a/framegallery/frame_connector/processors/base.py
+++ b/framegallery/frame_connector/processors/base.py
@@ -77,6 +77,11 @@ class UploadProcessor(abc.ABC):
     # Timeout (seconds) for the REST power-state probe. Short: it is a LAN request to
     # a TV that is either answering promptly or not answering at all.
     REST_TIMEOUT = 5
+    # The only TV port that speaks TLS and token auth. samsungtvws derives the whole
+    # transport from the port number -- ws:// vs wss://, whether the URL carries a
+    # token, http vs https for REST, and the SSL options -- by testing for exactly
+    # this value, so it is the single thing that distinguishes the two modes.
+    SECURE_PORT = 8002
     # How many previously uploaded images to delete in one batched call per cycle, and
     # the cap on the backlog we are prepared to remember.
     PENDING_DELETION_BATCH = 20
@@ -477,7 +482,20 @@ class UploadProcessor(abc.ABC):
 
         On the very first run the user must accept the prompt on the TV; the
         token is then written to `self._token_file` and reused silently after.
+
+        Only ``SECURE_PORT`` uses token auth. On the plain-WebSocket port the art
+        URL carries no token parameter at all, so pairing has nothing to
+        accomplish -- and the remote-control channel there rejects unauthenticated
+        clients outright with ``ms.channel.unauthorized``, which would abort every
+        reconnect and leave the app permanently disconnected.
         """
+        if self._port != self.SECURE_PORT:
+            logger.debug(
+                "Port %s uses plain WebSockets without token auth; skipping pairing.",
+                self._port,
+            )
+            return
+
         remote = SamsungTVWSAsyncRemote(
             host=self._ip_address,
             port=self._port,

--- a/tests/unit/framegallery/frame_connector/processors/test_base_lifecycle.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_base_lifecycle.py
@@ -125,3 +125,66 @@ async def test_shutdown_cancels_pinger_and_does_not_rearm() -> None:
     with patch(_CREATE_TASK) as create_task:
         proc._start_reconnection_pinger()  # noqa: SLF001
         create_task.assert_not_called()
+
+
+# --- token pairing only applies to the secure port ---
+
+
+@pytest.mark.asyncio
+async def test_pairing_is_skipped_on_the_plain_websocket_port() -> None:
+    """
+    On the plain-WebSocket port there is no token to obtain.
+
+    That port's art URL carries no token parameter, so pairing achieves nothing --
+    and its remote-control channel rejects unauthenticated clients with
+    ms.channel.unauthorized. Running pairing there would raise on every reconnect
+    and leave the app permanently disconnected.
+    """
+    proc = _build_processor()
+    proc._port = SingleAsyncProcessor.SECURE_PORT + 1  # noqa: SLF001 -- any non-secure port
+
+    with patch("framegallery.frame_connector.processors.base.SamsungTVWSAsyncRemote") as remote_cls:
+        await proc._ensure_token()  # noqa: SLF001
+
+    remote_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pairing_runs_on_the_secure_port() -> None:
+    """The secure port still pairs, so the token flow is unchanged for existing setups."""
+    proc = _build_processor()
+    proc._port = SingleAsyncProcessor.SECURE_PORT  # noqa: SLF001
+
+    remote = MagicMock()
+    remote.open = AsyncMock()
+    remote.close = AsyncMock()
+
+    with patch(
+        "framegallery.frame_connector.processors.base.SamsungTVWSAsyncRemote",
+        return_value=remote,
+    ) as remote_cls:
+        await proc._ensure_token()  # noqa: SLF001
+
+    remote_cls.assert_called_once()
+    assert remote_cls.call_args.kwargs["port"] == SingleAsyncProcessor.SECURE_PORT
+    remote.open.assert_awaited_once()
+    remote.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pairing_closes_the_remote_even_when_open_fails() -> None:
+    """A failed pairing must not leak the remote-control connection."""
+    proc = _build_processor()
+    proc._port = SingleAsyncProcessor.SECURE_PORT  # noqa: SLF001
+
+    remote = MagicMock()
+    remote.open = AsyncMock(side_effect=OSError("refused"))
+    remote.close = AsyncMock()
+
+    with (
+        patch("framegallery.frame_connector.processors.base.SamsungTVWSAsyncRemote", return_value=remote),
+        pytest.raises(OSError, match="refused"),
+    ):
+        await proc._ensure_token()  # noqa: SLF001
+
+    remote.close.assert_awaited_once()


### PR DESCRIPTION
## Context

Uploads to the Frame fail regularly with WebSocket close status **1005** — a code RFC 6455 reserves and forbids on the wire, so the TV is emitting a malformed close frame:

```
sync_thread: TV op 'upload local:2361' failed (attempt 1/1): ('Invalid close opcode %r', 1005)
```

A same-window comparison on a 2023 Frame (`QE32LS03CBUXXN`) suggested these are tied to the token-authenticated channel rather than to uploading itself:

| Channel | Uploads | close-1005 |
|---|---|---|
| `ws://:8001` (no TLS, no token) | 20 | **0** |
| `wss://:8002` (token), same half hour | 9 | **3** |

The 8002 figure matches that day's ~35% baseline, so the probe neither caused nor inflated it. This PR makes 8001 usable so the theory can be measured over a longer period.

## The change

`samsungtvws` derives the whole transport from the port number — `ws://` vs `wss://`, whether the URL carries a token, `http` vs `https` for the REST probe, and the SSL options — by testing for exactly `8002` in `connection.py`. So switching `tv_port` *ought* to be config-only, and for everything except pairing it is.

**Pairing was the exception, and it was fatal.** `reconnect()` calls `_ensure_token()` unconditionally:

```python
async def reconnect(self) -> None:
    await self._ensure_token()   # raises UnauthorizedError on 8001
    await self.open()            # never reached
```

The plain port's *remote-control* channel rejects unauthenticated clients with `ms.channel.unauthorized`, even though its *art-app* channel accepts them. Since the reconnect loop swallows and retries every 10s, setting `tv_port=8001` alone would have left the app looping forever, never connecting.

Pairing is now skipped on any non-secure port. It has nothing to accomplish there regardless — that port's art URL has no token parameter to carry:

```python
_URL_FORMAT     = "ws://{host}:{port}/api/v2/channels/{app}?name={name}"
_SSL_URL_FORMAT = "wss://{host}:{port}/api/v2/channels/{app}?name={name}&token={token}"
```

## Verified against a real TV

`_ensure_token()` now succeeds on **both** ports, where 8001 previously raised `UnauthorizedError`. The 20-upload probe used the same synchronous client `sync_thread` uses, so no engine change is required to try this.

## Scope

- Default stays `8002` — existing setups are unaffected.
- No other code changes were needed; the port flows cleanly from `settings.tv_port` through `base.py` to all four call sites (sync art, async art, REST probe, pairing remote), with no hardcoded `8002` anywhere else.
- README gains a "TV port" section with the transport comparison, the 1005 background, and how to measure whether switching helps.
- `.env.dist` and `config.py` document the choice inline.

## Testing

- **252 passed** (was 249); `ruff check` / `format --check` clean; suite also verified against a nonexistent `db_url`
- 3 new tests: pairing skipped on a non-secure port, pairing still runs on the secure port, and the remote is closed even when `open()` raises
- Confirmed end-to-end against the TV on both ports

## Caveats, stated in the README too

The 8001 result rests on 20 uploads against one TV on one firmware. It is framed as an experiment to measure — switch, then compare `grep -c "upload failed for" logs/framegallery.log` over a day — not as a guaranteed fix. 8001 is also unencrypted and unauthenticated on the LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
