### PR TITLE
docs: correct the TV port guidance; don't report a crash before connecting

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -2,7 +2,7 @@ db_url="sqlite:///./data/framegallery.db"
 gallery_path="./images"
 tv_ip_address="192.168.2.76"
 # 8002 = TLS + token auth (one-time "Allow" prompt); 8001 = plain WebSockets, no
-# pairing. Try 8001 if uploads fail with WebSocket close code 1005 -- see the
+# pairing. Stay on 8002 unless you are deliberately investigating -- see the
 # "TV port" section of the README.
 tv_port=8002
 # Device name registered on the TV (granted the auth token). Keep it stable;

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Create a `.env` file with your configuration. See `.env.dist` for all available 
 ```bash
 # Samsung TV Configuration
 tv_ip_address=192.168.1.100
-tv_port=8002                  # 8002 = TLS + token auth; 8001 = plain WebSockets, no pairing. See "TV port" below
+tv_port=8002                  # 8002 = TLS + token auth (default); 8001 = plain WebSockets. See "TV port" below
 tv_client_name=FrameGallery   # device name registered on the TV; keep stable to avoid re-pairing
 
 # Application Settings
@@ -193,23 +193,40 @@ everything from it:
 | Pairing | one-time "Allow" prompt on the TV | not required, and skipped automatically |
 | REST probe | `https` | `http` |
 
-Both are served by current Frame firmware — 8001 is not a legacy-only option. Switching is
-a one-line change; the app detects that 8001 needs no token and skips pairing. Note that
-8001 is unencrypted and unauthenticated on your LAN.
+Both ports are served by current Frame firmware — 8001 is not a legacy-only option, and
+was confirmed working on a 2023 model (`QE32LS03CBUXXN`). The app detects that 8001 needs
+no token and skips pairing automatically. Note that 8001 is unencrypted and
+unauthenticated on your LAN.
 
-**Why you might switch.** Some Frames abort uploads by closing the WebSocket with status
-1005, which surfaces as:
+**Stay on the default unless you are deliberately investigating.** 8001 exists here so the
+option is available and does not silently hang the reconnect loop; it is not a
+recommendation.
+
+**Background.** Some Frames abort uploads by closing the WebSocket with status 1005:
 
 ```
 sync_thread: TV op 'upload local:1234' failed: ('Invalid close opcode %r', 1005)
 ```
 
 1005 is reserved by RFC 6455 and must never appear on the wire, so the TV is sending a
-malformed close frame. On at least one 2023 Frame (`QE32LS03CBUXXN`) these failures were
-frequent on 8002 and absent on 8001 across a same-window comparison, which suggests they
-relate to the token-authenticated channel rather than to uploading itself. The sample was
-small, so treat 8001 as an experiment worth measuring rather than a guaranteed fix: switch,
-then compare `grep -c "upload failed for" logs/framegallery.log` over a day.
+malformed close frame. A short probe on one 2023 Frame saw 20 uploads on 8001 without a
+single 1005, against roughly a third failing that way on 8002 in the same period — which
+hinted the errors relate to the token-authenticated channel rather than to uploading
+itself.
+
+That hint has **not** held up in practice, and neither trial was conclusive:
+
+- The probe used a different client name, no token file, and a longer timeout, and ran
+  while the app still held the 8002 channel. Too many variables differed to attribute the
+  result to the port.
+- A production switch was abandoned after five minutes and a single real upload attempt.
+  That attempt failed with a *timeout* rather than a 1005, and the TV then wedged — but
+  the same wedge occurs on 8002 several times a day, so it proved nothing either way.
+
+If you want to settle it, the only useful test is a full day on 8001 — several hundred
+uploads — judged solely on `grep -c "Invalid close opcode" logs/framegallery.log` against
+the 8002 baseline. A TV wedge partway through does not disqualify the run, since those
+happen on both ports. Anything shorter will mislead you, as it did here.
 
 #### Database Migrations
 

--- a/framegallery/config.py
+++ b/framegallery/config.py
@@ -13,8 +13,8 @@ class Settings(BaseSettings):
     # 8002 speaks TLS with token auth and requires a one-time "Allow" prompt on the
     # TV; 8001 speaks plain WebSockets with no token and no pairing. The whole
     # transport follows from this number -- ws:// vs wss://, http vs https for the
-    # REST probe, and whether pairing runs at all. Try 8001 if uploads fail with
-    # WebSocket close code 1005; see the "TV port" section of the README.
+    # REST probe, and whether pairing runs at all. Stay on 8002 unless you are
+    # deliberately investigating; see the "TV port" section of the README.
     tv_port: int = 8002
     # Client identity registered on the TV and granted the auth token. Must stay
     # constant across restarts; change it only if you want the TV to re-pair

--- a/framegallery/frame_connector/art_mode_watchdog.py
+++ b/framegallery/frame_connector/art_mode_watchdog.py
@@ -123,6 +123,14 @@ class ArtModeWatchdog:
 
         art_mode = await self._processor.get_art_mode()
         if art_mode is None:
+            if not self._processor.is_connected:
+                # We never asked the TV anything: the processor has no connection yet.
+                # get_art_mode() returns None for that too, and reporting it as
+                # ART_UNAVAILABLE claims the art system crashed when nothing has been
+                # observed at all. That misreads every startup -- the first poll
+                # routinely lands before the connection is up -- and a false "most
+                # likely crashed" at boot is worse than admitting we do not know.
+                return TvHealth.UNKNOWN
             # REST answered but the art channel did not: the TV is alive and the art
             # system specifically has wedged. This is the signature of an Art Mode
             # crash, as opposed to the TV being off or someone watching television.

--- a/tests/unit/framegallery/frame_connector/test_art_mode_watchdog.py
+++ b/tests/unit/framegallery/frame_connector/test_art_mode_watchdog.py
@@ -10,6 +10,9 @@ from framegallery.frame_connector.art_mode_watchdog import ArtModeWatchdog, TvHe
 def _processor(*, powered: bool | None, art_mode: bool | None = None) -> MagicMock:
     """Build a processor stub whose two probes return the given readings."""
     processor = MagicMock()
+    # Explicit: a bare MagicMock attribute is truthy by accident, and whether the
+    # processor is connected now decides UNKNOWN vs ART_UNAVAILABLE.
+    processor.is_connected = True
     processor.is_tv_powered_on = AsyncMock(return_value=powered)
     processor.get_art_mode = AsyncMock(return_value=art_mode)
     processor.set_art_mode = AsyncMock(return_value=True)
@@ -146,3 +149,30 @@ async def test_probe_failure_does_not_kill_the_state() -> None:
 
     with pytest.raises(OSError, match="boom"):
         await _watchdog(processor).probe_once()
+
+
+@pytest.mark.asyncio
+async def test_not_yet_connected_is_unknown_not_a_crash_report() -> None:
+    """
+    Before the TV connection is up, the state is unknown -- not a crashed art system.
+
+    get_art_mode() returns None both when the art channel is wedged and when the
+    processor simply has no connection yet. Conflating them made every startup log
+    "the art system has most likely crashed", which is not merely noise: it was read
+    as evidence of a real fault during an incident and sent the diagnosis the wrong
+    way.
+    """
+    processor = _processor(powered=True, art_mode=None)
+    processor.is_connected = False
+
+    assert await _watchdog(processor).probe_once() is TvHealth.UNKNOWN
+    processor.note_art_mode.assert_called_once_with(active=None)
+
+
+@pytest.mark.asyncio
+async def test_connected_but_silent_art_channel_is_still_a_crash_report() -> None:
+    """With a live connection, an unanswerable art channel does mean the art system wedged."""
+    processor = _processor(powered=True, art_mode=None)
+    processor.is_connected = True
+
+    assert await _watchdog(processor).probe_once() is TvHealth.ART_UNAVAILABLE


### PR DESCRIPTION
## Context

#589 shipped a README section recommending `tv_port=8001` to avoid WebSocket close-1005 upload failures. That recommendation was followed, the switch was reverted five minutes later, and the diagnosis of *why* it failed turned out to be wrong too. This corrects both.

## 1. The 8001 recommendation was not supported by evidence

It rested on a probe of 20 uploads that saw zero close-1005 errors. But that probe used a **different client name**, **no token file**, a **longer timeout**, and ran **while the app still held the 8002 channel**. Too many variables differed to attribute the result to the port.

The production trial that followed proved nothing either:

- It ran for **five minutes** with **one real upload attempt** (the second was against an already-unreachable TV).
- That attempt failed with a **timeout**, not the close-1005 it was meant to avoid.
- The TV then wedged — but the same wedge happens on 8002 several times a day.

The README now documents 8001 neutrally, states plainly that the hypothesis is untested, and says what a conclusive trial would need: a full day and several hundred uploads, judged on `grep -c "Invalid close opcode"` against the 8002 baseline, with a mid-run TV wedge explicitly not disqualifying.

The default is unchanged, and the `config.py` / `.env.dist` comments no longer nudge toward 8001.

## 2. The watchdog reported a crash before it had connected

`_classify()` mapped a `None` from `get_art_mode()` straight to `ART_UNAVAILABLE` — *"the art system has most likely crashed"*. But `get_art_mode()` returns `None` for two different situations: the art channel is wedged, **or** the processor has no connection yet.

The watchdog's first poll routinely lands before the connection is up, so **every startup logged a crash that had not happened** — on both ports:

```
boot 09:10:34 [8002] -> art_unavailable   ← then art_on a minute later
boot 09:11:55 [8002] -> art_unavailable   ← then art_on
boot 20:03:20 [8001] -> art_unavailable
boot 20:08:33 [8002] -> art_unavailable   ← the revert, same thing
```

That is not merely log noise. During the incident I read the 8001 line as evidence the art channel was broken on that port, and reported it as the cause. It was a startup artifact appearing identically on 8002 seconds later.

Not-yet-connected now reports `UNKNOWN`. A silent art channel on a *live* connection still reports `ART_UNAVAILABLE`, so the genuine crash signature is unaffected.

## Testing

- **254 passed** (was 252); `ruff check` / `format --check` clean; also verified against a nonexistent `db_url`
- 2 new watchdog tests covering both sides of the distinction
- The shared test fixture now sets `is_connected` explicitly — it was previously truthy only by MagicMock accident, which is exactly the kind of thing that hides this class of bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
