### PR TITLE
chore: ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ logs/*
 .venv/
 .claude/
 tasks/
+CLAUDE.local.md


### PR DESCRIPTION
Claude Code reads `CLAUDE.local.md` alongside the committed `CLAUDE.md`, for notes that are specific to one machine or deployment and have no business in the repository.

Ignoring it means such notes cannot be committed by accident — including by a stray `git add -A` — and the protection survives a fresh clone.

One line, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)