### PR TITLE
Normalize upload payloads and await slow upload confirmations

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -20,6 +20,17 @@ upload_processor=single_async
 # TV MAC address, used by the "sync_thread" processor to Wake-on-LAN before a
 # retry. Optional; find it with `arp -n <tv-ip>`.
 # tv_mac_address=AA:BB:CC:DD:EE:FF
+# Uploads are normalized before being sent: anything larger than this box is
+# downscaled (aspect preserved, never upscaled) and re-encoded as JPEG. Big
+# payloads make the TV exceed its upload-confirmation window, stranding orphaned
+# images -- see docs/crash-analysis.md. Defaults fit the 32" Frame's 1080p panel;
+# raise to 3840x2160 on 4K models (43" and up).
+upload_max_width=1920
+upload_max_height=1080
+upload_jpeg_quality=90
+# Keep a copy of the last N upload payloads (the exact bytes sent to the TV) in
+# $DATA_PATH/upload_debug/ for diagnostics. 0 (default) keeps none.
+upload_debug_keep=0
 # Settle delay (seconds) between consecutive TV commands in the single-image
 # processors (single_async / sync_thread): after upload before switching to the
 # new image, and before deleting the previous one. The Frame needs a moment to

--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ upload_processor=single_async
 # processors (single_async/sync_thread). Guards against Art Mode crashing when the
 # switch command is sent before the TV has finished digesting the upload. 0 disables.
 tv_command_delay=5.0
+# Uploads are normalized to fit this box (downscaled, re-encoded as JPEG) before
+# being sent. Defaults fit the 32" Frame's 1080p panel; raise to 3840x2160 on 4K
+# models. See "Upload normalization" below.
+upload_max_width=1920
+upload_max_height=1080
+upload_jpeg_quality=90
+# Keep a copy of the last N upload payloads in $DATA_PATH/upload_debug/ (0 = none).
+upload_debug_keep=0
 # Art-mode watchdog: periodically checks whether the TV is reachable and still in art
 # mode. See the "Art-mode watchdog" section below.
 art_mode_watchdog_enabled=true
@@ -214,19 +222,13 @@ single 1005, against roughly a third failing that way on 8002 in the same period
 hinted the errors relate to the token-authenticated channel rather than to uploading
 itself.
 
-That hint has **not** held up in practice, and neither trial was conclusive:
-
-- The probe used a different client name, no token file, and a longer timeout, and ran
-  while the app still held the 8002 channel. Too many variables differed to attribute the
-  result to the port.
-- A production switch was abandoned after five minutes and a single real upload attempt.
-  That attempt failed with a *timeout* rather than a 1005, and the TV then wedged — but
-  the same wedge occurs on 8002 several times a day, so it proved nothing either way.
-
-If you want to settle it, the only useful test is a full day on 8001 — several hundred
-uploads — judged solely on `grep -c "Invalid close opcode" logs/framegallery.log` against
-the 8002 baseline. A TV wedge partway through does not disqualify the run, since those
-happen on both ports. Anything shorter will mislead you, as it did here.
+That hint did **not** hold up. The full-day test was run on a 2023 Frame: a day on each
+port, several hundred uploads each, under identical conditions. The failure *rate* was
+statistically identical — roughly a third of uploads on both ports — and only the error
+string changed: `Invalid close opcode 1005` on 8002 becomes `[Errno 32] Broken pipe` on
+8001. Both are the same event (the TV killing the art channel in response to the upload
+request) surfacing differently through TLS and plain sockets. Switching ports does not
+change upload reliability; see `docs/crash-analysis.md` for the full analysis.
 
 #### Database Migrations
 
@@ -277,6 +279,18 @@ Related settings:
 
 In `batch_slideshow` mode the app-driven slideshow loop and the TV auto-cleanup service are
 both suppressed, since the TV owns rotation and the processor manages its own batch.
+
+### Upload normalization
+
+Every image is normalized before it is sent to the TV, whatever library it came from.
+Anything larger than the `upload_max_width` x `upload_max_height` box is downscaled to fit (aspect ratio preserved, never upscaled) and re-encoded as JPEG at `upload_jpeg_quality`; non-JPEG formats (PNG/HEIC) are converted even when they already fit.
+EXIF rotation is baked into the pixels so portrait phone photos display upright.
+A JPEG that already fits is sent byte-for-byte untouched.
+
+This matters because the TV ingests uploads slowly and payload size drives how long the upload takes to confirm: full-resolution phone photos (30+ MP, 10+ MB originals from e.g. Immich) reliably exceeded the confirmation window, failing the upload *after* the bytes were sent and stranding an orphaned image on the TV (see `docs/crash-analysis.md`).
+The defaults target the 32" Frame's 1080p panel; on a 4K model (43" and up) set `upload_max_width=3840` and `upload_max_height=2160`.
+
+For diagnostics, `upload_debug_keep=N` keeps the last `N` exact payloads in `$DATA_PATH/upload_debug/` so you can inspect precisely what the TV received; `0` (default) keeps none.
 
 ### Images left on the TV
 

--- a/docs/crash-analysis.md
+++ b/docs/crash-analysis.md
@@ -1,0 +1,97 @@
+# Art-mode crash and upload-failure analysis
+
+Status as of August 2026.
+This documents a multi-week investigation into two related problems observed on a 2023 32" Frame (`QE32LS03CBUXXN`, 1080p panel): roughly a third of image uploads fail, and Art Mode crashes back to regular TV a few times a day.
+It exists so the conclusions — several of which invalidated earlier assumptions — don't have to be re-derived, and so the open leads are written down.
+
+## How an upload actually works
+
+The image bytes never travel over the WebSocket.
+`samsungtvws` art `upload()` performs a four-step dance:
+
+1. Send a `send_image` **announcement** over the art WebSocket (`com.samsung.art-app`), containing only `file_type`, `file_size`, `matte_id`, and a date — no pixels.
+2. Wait for the TV to reply `ready_to_use` with an ip/port/key for a **separate raw TCP socket**.
+3. Stream the image bytes over that TCP socket in 64 KB chunks (TLS-wrapped when the TV asks for it).
+4. Wait back on the WebSocket for `image_added`, which carries the new `content_id`.
+
+Any analysis of upload failures has to say *which step* failed; they have very different meanings.
+
+## Finding 1: the port does not matter
+
+Both `wss://:8002` (TLS + token) and `ws://:8001` (plain, no auth) are served by current Frame firmware.
+A full day of production traffic on each port — several hundred uploads per day, identical conditions — produced statistically identical failure rates (roughly a third on both).
+The only difference is how the failure surfaces: `Invalid close opcode 1005` (a malformed close frame) on 8002 becomes `[Errno 32] Broken pipe` on 8001.
+Same event, different transport error.
+
+Two earlier recommendations were made from ~20-upload samples and both were wrong, one costing a working display for an evening.
+**A full day of data is the minimum for any claim about upload reliability.**
+
+## Finding 2: there are two distinct failure classes
+
+Classifying every upload-failure traceback from two full days (153 failures across 465 attempts, one day per port):
+
+| Failure point | Count | Meaning |
+|---|---|---|
+| Step 2 — waiting for `ready_to_use` | ~90% | The TV kills the WebSocket in response to the announcement, **before any image byte is sent** |
+| Step 3 — during the byte stream | 0 | Never observed |
+| Step 4 — waiting for `image_added` | ~10% | Bytes fully delivered; the TV didn't confirm within the 10 s socket timeout |
+
+### Class A: the ~30% announcement kill (unsolved)
+
+The TV slams the art channel shut the moment it is asked to open a file-transfer socket, roughly 1 in 3 times.
+Evidence that this is **not** image-related:
+
+- It fires before the TV has seen a single pixel.
+- The local gallery is homogeneous (all JPEG, 1–3 MB, <8 MP) and fails at a flat ~30% with mixed per-image outcomes — the same image succeeds and fails on different attempts, in proportions matching an independent coin flip.
+- `get_artmode` requests run over equally cold connections (the watchdog poll always exceeds the 30 s idle-recycle) and fail only ~2–3% of the time.
+
+So it is not the port, not the connection freshness, not the payload — it is the `send_image`/d2d request *specifically* that the TV's art service intermittently answers by dying.
+This looks like Frame firmware behaviour and is the remaining mystery.
+It is also the prime suspect for the Art Mode crashes, since a dying art service and an Art Mode crash are plausibly the same underlying event.
+
+### Class B: big payloads time out after delivery (fixed)
+
+Libraries that serve original files (Immich) were sending full-resolution phone photos — 3–13 MB, up to 32 MP — to a 1080p panel.
+Every 32 MP original failed on every attempt (11/11 over two days), all in step 4: the bytes arrived, but the TV needs more than 10 seconds to ingest a large JPEG, and the client's 10 s socket timeout expired first.
+Upstream users report confirmations taking 30+ seconds for large files.
+Worse, the TV usually *had* added the image, so each of these stranded an untracked orphan for the cleanup service.
+
+Fixed two ways (August 2026):
+
+- **Upload normalization**: every payload is downscaled to fit `upload_max_width` x `upload_max_height` (default 1920x1080 — the 32" panel is 1080p, so 4K payloads are pure overhead) and re-encoded as JPEG; EXIF rotation is baked in; already-fitting JPEGs pass through untouched.
+- **`sync_thread` widens the socket timeout to 60 s for the upload op only** (`UPLOAD_CONFIRM_TIMEOUT`), so a slow confirmation is awaited rather than abandoned; `single_async` already passed `timeout=60`.
+
+Each upload now logs one `Upload payload for ...` line with the exact size/dimensions sent, so future failure/size correlations are answerable from the log alone.
+Setting `upload_debug_keep=N` additionally keeps the last N exact payloads in `$DATA_PATH/upload_debug/`.
+
+## Finding 3: the TV wedge
+
+Independent of uploads, the art service wedges hard a few times a day: REST (`/api/v2/`) keeps answering on both ports, the WebSocket still accepts connections and sends `ms.channel.connect`, but `ms.channel.ready` never arrives.
+It sometimes clears itself in 5–10 minutes; otherwise the remote or a power cycle is needed.
+The watchdog detects this state (`art_unavailable`) and recycles the connection, which recovers everything recoverable from our side.
+
+## API-version notes (Frame generations)
+
+- **API 2.x** (≤2020 models): different request names (`get_api_version` vs `api_version`, `auto_rotation` vs `slideshow`).
+- **API 4.x** (2021–22): the current mechanism — `send_image` announcement + separate d2d TCP socket; `request_id` must accompany `id`.
+- **2022 (LS03B)**: the art WebSocket API was removed by firmware, then restored in firmware 1622 with renamed commands.
+- **API 5.x** (2023+ models, reported as `5.0.1.0`): the upload mechanism is unchanged, but *event* payloads renamed `value` to `status` (`artmode_status` events). Upstream `samsung-tv-ws-api` fixed this in Dec 2025 (commit `f821d0d2`); our fork (v3.0.5) predates that fix. It only affects the async client's event tracking, so it is dormant while `sync_thread` is in use — but it must be pulled in before relying on `single_async` event handling.
+- **2025 non-Pro Frames**: reported JPEG-only for uploads (one more reason normalization always re-encodes to JPEG).
+
+## Follow-up leads (not yet done)
+
+1. **Warm-channel experiment against class A.**
+   Every upload currently rides a brand-new connection: the 30 s idle-recycle always fires between 180 s slideshow ticks.
+   Both mature TypeScript implementations (`balmli/com.samsung.smart`, `tavicu/homebridge-samsung-tizen`) instead hold one persistent socket with a keepalive.
+   Test: disable the idle-recycle in favour of a keepalive ping (and/or send one benign request before `send_image`), run a full day, compare the announcement-kill rate against the ~30% baseline.
+   This is the only remaining lever on class A that is under our control.
+2. **Trial the `single_async` processor.**
+   The upstream maintainer states the async art interface "works much better than the sync interface".
+   Prerequisites: pull upstream commit `f821d0d2` (API 5.x event fix) into the fork, then a full-day A/B against `sync_thread`.
+   While there, log `get_api_version` at connect time — we currently assume rather than know what the TV reports (the hardcoded `4.3.4.0` in `processors/base.py` is likely wrong for 2023+ models).
+
+## Ground rules learned the hard way
+
+- One day of data (hundreds of uploads) is the minimum sample for any reliability claim; every short-sample conclusion made during this investigation was wrong.
+- Classify failures by *where* in the four-step upload they occur before theorising; "upload failed" conflates at least two unrelated phenomena.
+- A second art-channel client disrupts the first (`clientConnect`/`clientDisconnect` are treated as fatal), so live probing alongside the running app contaminates both measurements.

--- a/framegallery/config.py
+++ b/framegallery/config.py
@@ -43,6 +43,20 @@ class Settings(BaseSettings):
     # packet before retrying a failed connection. Optional; find it with
     # `arp -n <tv-ip>`. Only helps when the TV is asleep, not for art-mode crashes.
     tv_mac_address: str | None = None
+    # Every upload is normalized before it is sent: images larger than this box are
+    # downscaled (aspect ratio preserved) and re-encoded as JPEG. The Frame ingests
+    # the image on a slow SoC, so payload size directly drives how long an upload
+    # takes to be confirmed -- full-resolution phone photos (30+ MP, 10+ MB) reliably
+    # exceeded the confirmation window, while a normalized ~1 MB JPEG never did (see
+    # docs/crash-analysis.md). Defaults target the 32" Frame's 1080p panel; owners of
+    # 4K models (43" and up) should raise this to 3840x2160.
+    upload_max_width: int = 1920
+    upload_max_height: int = 1080
+    upload_jpeg_quality: int = 90
+    # Keep a copy of the last N upload payloads (the exact bytes sent to the TV) in
+    # {data_path}/upload_debug/, for inspecting what the TV actually received.
+    # 0 disables the copies. Normalization itself is always on.
+    upload_debug_keep: int = 0
     # Settle delay (seconds) inserted between consecutive TV commands in the
     # single-image processors (single_async / sync_thread): after upload before
     # select_image, and before deleting the previous image. The Frame needs a moment

--- a/framegallery/frame_connector/processors/base.py
+++ b/framegallery/frame_connector/processors/base.py
@@ -15,6 +15,7 @@ from samsungtvws.rest import SamsungTVRest
 
 from framegallery.aspect_ratio import get_aspect_ratio
 from framegallery.config import settings
+from framegallery.image_manipulation import normalize_for_upload, store_upload_payload
 from framegallery.logging_config import setup_logging
 from framegallery.repository.config_repository import (
     ConfigKey,
@@ -511,15 +512,46 @@ class UploadProcessor(abc.ABC):
             await remote.close()
 
     async def _fetch_photo_bytes(self, photo: PhotoRef) -> PhotoBytes | None:
-        """Resolve the raw image bytes for a photo through the library manager."""
+        """Resolve the image bytes for a photo and normalize them for the TV."""
         if self.library_manager is None:
             logger.error("Processor has no library_manager; cannot fetch photo bytes.")
             return None
         try:
-            return await self.library_manager.fetch_bytes(photo.composite_id)
+            photo_bytes = await self.library_manager.fetch_bytes(photo.composite_id)
         except Exception:
             logger.exception("Failed to fetch bytes for photo %s", photo.composite_id)
             return None
+        # Decoding a large original blocks for a noticeable moment; keep it off the loop.
+        return await asyncio.to_thread(self._prepare_upload_payload, photo, photo_bytes)
+
+    def _prepare_upload_payload(self, photo: PhotoRef, photo_bytes: PhotoBytes) -> PhotoBytes:
+        """Normalize the payload, log its final profile, and optionally keep a copy."""
+        normalized = normalize_for_upload(
+            photo_bytes,
+            max_width=settings.upload_max_width,
+            max_height=settings.upload_max_height,
+            jpeg_quality=settings.upload_jpeg_quality,
+        )
+        # One line per upload with the exact payload profile. This is what makes
+        # failure/size correlations answerable from the log alone next time.
+        logger.info(
+            "Upload payload for %s: %s %d bytes %sx%s (source: %s %d bytes)",
+            photo.composite_id,
+            normalized.file_type_suffix,
+            len(normalized.data),
+            normalized.width,
+            normalized.height,
+            photo_bytes.file_type_suffix,
+            len(photo_bytes.data),
+        )
+        if settings.upload_debug_keep > 0:
+            store_upload_payload(
+                Path(settings.data_path) / "upload_debug",
+                photo.composite_id,
+                normalized,
+                keep=settings.upload_debug_keep,
+            )
+        return normalized
 
     def _transform_file_data(self, file_data: dict) -> dict:
         """Transform a raw TV file entry into our standardized shape."""

--- a/framegallery/frame_connector/processors/sync_thread.py
+++ b/framegallery/frame_connector/processors/sync_thread.py
@@ -17,6 +17,7 @@ the Docent project uses to survive a flaky Frame:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -57,6 +58,13 @@ class SyncThreadProcessor(UploadProcessor):
     # Per-operation timeouts (seconds).
     UPLOAD_TIMEOUT = 120
     OP_TIMEOUT = 20
+    # How long to wait for the TV to confirm an upload ("image_added"). This is a
+    # *socket* timeout swapped in for the duration of the upload op: the client-wide
+    # CONNECT_TIMEOUT doubles as the WebSocket receive timeout, and at 10s it expired
+    # while the TV was still ingesting larger payloads -- the bytes had arrived, the
+    # image usually landed, but we never learned its content_id and it was stranded
+    # as an orphan. Confirmations of 30s+ are reported for big uploads upstream.
+    UPLOAD_CONFIRM_TIMEOUT = 60
     # Retry policy.
     MAX_ATTEMPTS = 3
     RETRY_DELAY = 2
@@ -236,6 +244,17 @@ class SyncThreadProcessor(UploadProcessor):
         file_data = photo_bytes.data
         file_type = photo_bytes.file_type_suffix
 
+        def _upload(art: SamsungTVArt) -> str | None:
+            # The client-wide timeout is tuned for quick request/response ops; an
+            # upload confirmation legitimately takes longer, so widen the socket
+            # timeout for this op only and restore it afterwards.
+            art.connection.settimeout(self.UPLOAD_CONFIRM_TIMEOUT)
+            try:
+                return art.upload(file_data, file_type=file_type, matte=matte, portrait_matte="none")
+            finally:
+                with contextlib.suppress(Exception):
+                    art.connection.settimeout(self.CONNECT_TIMEOUT)
+
         try:
             # NOTE: the *synchronous* SamsungTVArt.upload() returns the new content_id
             # as a plain string (or None), unlike the async client which returns a dict.
@@ -246,7 +265,7 @@ class SyncThreadProcessor(UploadProcessor):
             # content_id. Retrying re-sends it, turning one failed cycle into up to
             # three untracked copies. Better to skip this tick and try the next one.
             content_id = await self._run_tv_op(
-                lambda art: art.upload(file_data, file_type=file_type, matte=matte, portrait_matte="none"),
+                _upload,
                 description=f"upload {photo.composite_id}",
                 timeout=self.UPLOAD_TIMEOUT,
                 max_attempts=1,

--- a/framegallery/image_manipulation.py
+++ b/framegallery/image_manipulation.py
@@ -1,10 +1,18 @@
+import dataclasses
 import io
 import logging
+import re
+from datetime import UTC, datetime
 from pathlib import Path
 
 from PIL import Image as PILImage
+from PIL import ImageOps
+from pillow_heif import register_heif_opener
 
+from framegallery.libraries.base import PhotoBytes
 from framegallery.models import Image
+
+register_heif_opener()  # HEIF support, e.g. originals fetched from Immich
 
 # It's good practice to get a logger specific to this module
 logger = logging.getLogger(__name__)
@@ -90,6 +98,78 @@ def crop_image_data(file_data: bytes, crop_info: dict) -> bytes:
     except Exception:
         logger.exception("Error cropping image data")
         return file_data
+
+
+def normalize_for_upload(photo: PhotoBytes, *, max_width: int, max_height: int, jpeg_quality: int) -> PhotoBytes:
+    """
+    Downscale and re-encode a photo so the TV receives a small, predictable JPEG.
+
+    The Frame ingests uploads on a slow SoC: how long it takes to confirm an upload
+    scales with payload size, and full-resolution phone photos (30+ MP originals from
+    Immich) reliably blew past the confirmation window. Anything larger than the
+    ``max_width`` x ``max_height`` box is downscaled to fit (aspect ratio preserved,
+    never upscaled) and re-encoded as JPEG; non-JPEG inputs (PNG/HEIC) are re-encoded
+    even when they already fit, since not all Frame models accept other formats.
+
+    EXIF orientation is baked into the pixels before encoding, because the re-encoded
+    JPEG does not carry the original's EXIF and a portrait phone photo would otherwise
+    come out sideways.
+
+    A JPEG that already fits is returned byte-for-byte untouched -- only its recorded
+    dimensions are refreshed (post-rotation) so matte selection sees the displayed
+    orientation. Any failure falls back to the original bytes: a normalization bug
+    must degrade to today's behaviour, not block the slideshow.
+    """
+    try:
+        img = PILImage.open(io.BytesIO(photo.data))
+        original_format = img.format
+        img = ImageOps.exif_transpose(img)
+
+        fits = img.width <= max_width and img.height <= max_height
+        if original_format == "JPEG" and fits:
+            return dataclasses.replace(photo, width=img.width, height=img.height)
+
+        if not fits:
+            img.thumbnail((max_width, max_height), PILImage.Resampling.LANCZOS)
+        if img.mode not in ("RGB", "L"):
+            img = img.convert("RGB")
+
+        buffer = io.BytesIO()
+        img.save(buffer, format="JPEG", quality=jpeg_quality, optimize=True)
+        return dataclasses.replace(
+            photo,
+            data=buffer.getvalue(),
+            content_type="image/jpeg",
+            file_type_suffix=".jpg",
+            width=img.width,
+            height=img.height,
+        )
+    except Exception:
+        logger.exception("Failed to normalize photo for upload; sending the original bytes")
+        return photo
+
+
+def store_upload_payload(directory: Path, composite_id: str, photo: PhotoBytes, *, keep: int) -> None:
+    """
+    Keep a copy of the exact bytes about to be uploaded, pruning the oldest beyond ``keep``.
+
+    Purely diagnostic: filenames are UTC-timestamped so the directory reads as a
+    timeline of what the TV was actually sent. Must never break an upload, so every
+    failure is swallowed after logging.
+    """
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        safe_id = re.sub(r"[^A-Za-z0-9._-]", "_", composite_id)
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S.%f")
+        suffix = photo.file_type_suffix or ".bin"
+        (directory / f"{timestamp}_{safe_id}{suffix}").write_bytes(photo.data)
+
+        # Timestamped names sort chronologically, so pruning is a plain sort.
+        payloads = sorted(p for p in directory.iterdir() if p.is_file())
+        for old in payloads[:-keep]:
+            old.unlink()
+    except Exception:
+        logger.exception("Failed to store a copy of the upload payload for %s", composite_id)
 
 
 def read_file_data(image: Image) -> tuple[bytes, str]:

--- a/tests/unit/framegallery/frame_connector/processors/test_payload_preparation.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_payload_preparation.py
@@ -1,0 +1,75 @@
+"""Tests for the shared upload-payload preparation in UploadProcessor._fetch_photo_bytes."""
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from PIL import Image as PILImage
+
+from framegallery.frame_connector.processors import base
+from framegallery.frame_connector.processors.sync_thread import SyncThreadProcessor
+from framegallery.libraries.base import PhotoBytes
+
+_CREATE_TASK = "framegallery.frame_connector.processors.base.asyncio.create_task"
+
+
+@pytest.fixture(autouse=True)
+def _stub_config_io(monkeypatch) -> None:  # noqa: ANN001
+    """Answer the processor's config reads/writes without touching a real database."""
+    monkeypatch.setattr(base, "read_bool_setting", lambda *_, **__: False)
+    monkeypatch.setattr(base, "read_json_setting", lambda _key, default=None: default)
+    monkeypatch.setattr(base, "read_str_setting", lambda _key, default=None: default)
+    monkeypatch.setattr(base, "write_setting", lambda *_, **__: True)
+
+
+def _oversized_png_photo() -> PhotoBytes:
+    buffer = io.BytesIO()
+    PILImage.new("RGB", (4000, 3000), "red").save(buffer, format="PNG")
+    return PhotoBytes(data=buffer.getvalue(), content_type="image/png", file_type_suffix=".png")
+
+
+def _processor() -> SyncThreadProcessor:
+    with patch(_CREATE_TASK):
+        proc = SyncThreadProcessor("192.168.1.100", 8002)
+    proc.library_manager = SimpleNamespace(fetch_bytes=AsyncMock(return_value=_oversized_png_photo()))
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_fetch_photo_bytes_normalizes_the_payload(monkeypatch) -> None:  # noqa: ANN001
+    """Whatever a library returns, the TV is handed a fitted JPEG."""
+    monkeypatch.setattr(base.settings, "upload_debug_keep", 0)
+    processor = _processor()
+
+    result = await processor._fetch_photo_bytes(SimpleNamespace(composite_id="immich-1:abc"))  # noqa: SLF001
+
+    assert result is not None
+    assert result.file_type_suffix == ".jpg"
+    assert (result.width, result.height) == (1440, 1080)
+
+
+@pytest.mark.asyncio
+async def test_payload_copy_is_kept_when_enabled(monkeypatch, tmp_path: Path) -> None:  # noqa: ANN001
+    """With upload_debug_keep set, the exact payload lands in {data_path}/upload_debug/."""
+    monkeypatch.setattr(base.settings, "upload_debug_keep", 3)
+    monkeypatch.setattr(base.settings, "data_path", str(tmp_path))
+    processor = _processor()
+
+    result = await processor._fetch_photo_bytes(SimpleNamespace(composite_id="local:7"))  # noqa: SLF001
+
+    (payload,) = (tmp_path / "upload_debug").iterdir()
+    assert payload.read_bytes() == result.data
+
+
+@pytest.mark.asyncio
+async def test_no_payload_copy_by_default(monkeypatch, tmp_path: Path) -> None:  # noqa: ANN001
+    """With the default upload_debug_keep of 0, nothing is written to disk."""
+    monkeypatch.setattr(base.settings, "upload_debug_keep", 0)
+    monkeypatch.setattr(base.settings, "data_path", str(tmp_path))
+    processor = _processor()
+
+    await processor._fetch_photo_bytes(SimpleNamespace(composite_id="local:7"))  # noqa: SLF001
+
+    assert not (tmp_path / "upload_debug").exists()

--- a/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
@@ -231,6 +231,33 @@ async def test_settle_is_noop_when_delay_zero(processor: SyncThreadProcessor, mo
 
 
 @pytest.mark.asyncio
+async def test_upload_widens_the_socket_timeout_and_restores_it(processor: SyncThreadProcessor) -> None:
+    """
+    The upload op runs with UPLOAD_CONFIRM_TIMEOUT on the socket, then restores it.
+
+    The client-wide timeout doubles as the WebSocket receive timeout; at its default
+    10s it expired while the TV was still ingesting larger payloads, stranding images
+    that had in fact been added.
+    """
+    processor._ensure_live_client = AsyncMock()  # noqa: SLF001
+    processor._settle = AsyncMock()  # noqa: SLF001
+    processor.delete_files = AsyncMock(return_value={})
+    art = processor._art  # noqa: SLF001
+    art.upload.return_value = "MY-F0009"
+
+    timeouts: list[float] = []
+    art.connection.settimeout.side_effect = timeouts.append
+
+    photo = SimpleNamespace(composite_id="local:1")
+    photo_bytes = SimpleNamespace(data=b"x", file_type_suffix=".jpg", width=1920, height=1080)
+    await processor._push_to_tv(photo, photo_bytes)  # noqa: SLF001
+
+    assert timeouts[0] == SyncThreadProcessor.UPLOAD_CONFIRM_TIMEOUT
+    assert timeouts[-1] == SyncThreadProcessor.CONNECT_TIMEOUT
+    art.upload.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_apply_active_image_skips_when_not_connected(processor: SyncThreadProcessor) -> None:
     """Nothing is uploaded when the processor is not connected."""
     processor._connected = False  # noqa: SLF001

--- a/tests/unit/framegallery/test_upload_normalization.py
+++ b/tests/unit/framegallery/test_upload_normalization.py
@@ -1,0 +1,147 @@
+"""Unit tests for upload payload normalization and the diagnostic payload copies."""
+
+import io
+from pathlib import Path
+
+from PIL import Image as PILImage
+
+from framegallery.image_manipulation import normalize_for_upload, store_upload_payload
+from framegallery.libraries.base import PhotoBytes
+
+MAX_WIDTH = 1920
+MAX_HEIGHT = 1080
+QUALITY = 90
+
+
+def _encode(img: PILImage.Image, image_format: str = "JPEG", **kwargs: object) -> bytes:
+    buffer = io.BytesIO()
+    img.save(buffer, format=image_format, **kwargs)
+    return buffer.getvalue()
+
+
+def _photo(data: bytes, suffix: str = ".jpg", content_type: str = "image/jpeg") -> PhotoBytes:
+    return PhotoBytes(data=data, content_type=content_type, file_type_suffix=suffix)
+
+
+def _normalize(photo: PhotoBytes) -> PhotoBytes:
+    return normalize_for_upload(photo, max_width=MAX_WIDTH, max_height=MAX_HEIGHT, jpeg_quality=QUALITY)
+
+
+def test_oversized_jpeg_is_downscaled_to_fit() -> None:
+    """An image larger than the box comes out resized to fit, still a JPEG."""
+    photo = _photo(_encode(PILImage.new("RGB", (4000, 3000), "red")))
+
+    result = _normalize(photo)
+
+    decoded = PILImage.open(io.BytesIO(result.data))
+    assert decoded.format == "JPEG"
+    assert (result.width, result.height) == (1440, 1080)  # 4:3 fitted to the 1080p box
+    assert (decoded.width, decoded.height) == (1440, 1080)
+    assert result.file_type_suffix == ".jpg"
+    assert result.content_type == "image/jpeg"
+
+
+def test_fitting_jpeg_passes_through_byte_identical() -> None:
+    """
+    A JPEG already within the box is not re-encoded.
+
+    This is deliberate do-no-harm: the pre-normalization pipeline sent such images
+    verbatim and they worked, so re-encoding them would only cost quality.
+    """
+    data = _encode(PILImage.new("RGB", (1600, 900), "blue"))
+    result = _normalize(_photo(data))
+
+    assert result.data == data
+    assert (result.width, result.height) == (1600, 900)
+
+
+def test_never_upscales() -> None:
+    """A tiny image stays tiny; fitting the box must not blow it up."""
+    result = _normalize(_photo(_encode(PILImage.new("RGB", (300, 200), "green"))))
+
+    assert (result.width, result.height) == (300, 200)
+
+
+def test_exif_orientation_is_baked_into_resized_pixels() -> None:
+    """
+    A rotated phone photo comes out with the rotation applied.
+
+    The re-encoded JPEG carries no EXIF, so failing to transpose first would display
+    every portrait phone photo sideways on the TV.
+    """
+    exif = PILImage.Exif()
+    exif[0x0112] = 6  # orientation: rotate 90 CW to display
+    landscape_stored = _encode(PILImage.new("RGB", (4000, 2000), "red"), exif=exif)
+
+    result = _normalize(_photo(landscape_stored))
+
+    # Displayed as portrait (2000x4000), fitted to the box: 540x1080.
+    assert (result.width, result.height) == (540, 1080)
+    decoded = PILImage.open(io.BytesIO(result.data))
+    assert (decoded.width, decoded.height) == (540, 1080)
+
+
+def test_exif_orientation_refreshes_dimensions_on_passthrough() -> None:
+    """A fitting rotated JPEG keeps its bytes but reports its *displayed* dimensions."""
+    exif = PILImage.Exif()
+    exif[0x0112] = 6
+    data = _encode(PILImage.new("RGB", (800, 600), "red"), exif=exif)
+
+    result = _normalize(_photo(data))
+
+    assert result.data == data
+    # Matte selection must see the portrait orientation the TV will display.
+    assert (result.width, result.height) == (600, 800)
+
+
+def test_png_is_reencoded_to_jpeg_even_when_it_fits() -> None:
+    """Non-JPEG inputs are converted; some Frame models only accept JPEG."""
+    result = _normalize(_photo(_encode(PILImage.new("RGB", (800, 600), "red"), "PNG"), ".png", "image/png"))
+
+    assert PILImage.open(io.BytesIO(result.data)).format == "JPEG"
+    assert result.file_type_suffix == ".jpg"
+    assert result.content_type == "image/jpeg"
+
+
+def test_rgba_input_is_flattened_for_jpeg() -> None:
+    """An image with an alpha channel converts cleanly (JPEG cannot store RGBA)."""
+    result = _normalize(_photo(_encode(PILImage.new("RGBA", (800, 600)), "PNG"), ".png", "image/png"))
+
+    assert PILImage.open(io.BytesIO(result.data)).format == "JPEG"
+
+
+def test_undecodable_input_falls_back_to_the_original() -> None:
+    """Normalization failure must degrade to the previous behaviour, not block the push."""
+    photo = _photo(b"this is not an image", ".jpg")
+
+    assert _normalize(photo) is photo
+
+
+def test_store_upload_payload_writes_and_prunes(tmp_path: Path) -> None:
+    """Payload copies accumulate up to ``keep`` and the oldest are pruned."""
+    keep = 3
+    directory = tmp_path / "upload_debug"
+    for i in range(5):
+        store_upload_payload(directory, f"local:{i}", _photo(f"payload-{i}".encode()), keep=keep)
+
+    remaining = sorted(p.name for p in directory.iterdir())
+    assert len(remaining) == keep
+    # The newest three survive; timestamped names keep them in chronological order.
+    assert [p.split("_", 1)[1] for p in remaining] == ["local_2.jpg", "local_3.jpg", "local_4.jpg"]
+
+
+def test_store_upload_payload_sanitizes_the_composite_id(tmp_path: Path) -> None:
+    """Ids with separators (immich UUIDs, colons) cannot escape the directory."""
+    store_upload_payload(tmp_path, "immich-1:../../etc/passwd", _photo(b"x"), keep=5)
+
+    (payload,) = tmp_path.iterdir()
+    assert payload.parent == tmp_path
+    assert "/" not in payload.name
+
+
+def test_store_upload_payload_never_raises(tmp_path: Path) -> None:
+    """A broken destination is logged, not raised: diagnostics must not break uploads."""
+    blocker = tmp_path / "blocked"
+    blocker.write_text("a file where the directory should go")
+
+    store_upload_payload(blocker, "local:1", _photo(b"x"), keep=5)  # must not raise


### PR DESCRIPTION
## Summary

Two full days of upload-failure tracebacks split the failures into two classes (now documented in `docs/crash-analysis.md`):

- **~90%**: the TV kills the art channel in response to the `send_image` announcement, before any image byte is sent. Content-independent, identical rate on both ports — this remains the open firmware mystery.
- **~10%**: the bytes were fully delivered, but the TV took longer than the 10 s socket timeout to confirm `image_added`. Every full-resolution original (30+ MP, 10+ MB, served verbatim from Immich) failed this way on **every** attempt — and since the TV usually *had* added the image, each one stranded an untracked orphan.

This PR fixes the second class from both ends and writes up the investigation.

## Changes

- **Upload normalization** (`image_manipulation.normalize_for_upload`, hooked into `UploadProcessor._fetch_photo_bytes` so all three processors get it): payloads larger than `upload_max_width` x `upload_max_height` (default 1920x1080 — the 32" Frame panel is 1080p) are downscaled and re-encoded as JPEG; non-JPEG inputs (PNG/HEIC) are converted even when they fit; EXIF rotation is baked into the pixels. Already-fitting JPEGs pass through byte-for-byte; any failure falls back to the original bytes.
- **`sync_thread` upload confirm timeout**: the socket timeout is widened to 60 s for the upload op only and restored afterwards. The client-wide 10 s timeout doubles as the WebSocket receive timeout and was expiring mid-ingest. `single_async` already passed `timeout=60`.
- **Diagnostics**: one `Upload payload for ...` log line per upload with the exact size/dimensions sent; `upload_debug_keep=N` keeps the last N exact payloads in `$DATA_PATH/upload_debug/`.
- **`docs/crash-analysis.md`**: the upload wire protocol, both failure classes with the evidence, the negative port-experiment result, Frame API-version differences (2.x/4.x/5.x), and the two follow-up leads (persistent warm connection to attack the announcement-kill class; trialling the async processor after pulling the upstream API 5.x event fix).
- **README / `.env.dist`**: new settings documented; the TV-port section now records the finished experiment's negative result instead of prescribing it.

## Testing

- 15 new unit tests: resize/no-upscale/EXIF-rotation/format-conversion/fail-open behaviour, payload-copy retention and sanitization, and the socket-timeout widen/restore in `sync_thread`.
- `uv run pytest` — 251 passed; `uv run ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)