### PR TITLE
Optional TV connection keepalive for the sync_thread processor

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -20,6 +20,11 @@ upload_processor=single_async
 # TV MAC address, used by the "sync_thread" processor to Wake-on-LAN before a
 # retry. Optional; find it with `arp -n <tv-ip>`.
 # tv_mac_address=AA:BB:CC:DD:EE:FF
+# Keep the sync_thread TV connection warm: send a WebSocket ping whenever it has
+# been idle this many seconds, instead of tearing it down and rebuilding it per
+# upload (the 30s idle-recycle). 0 (default) disables the keepalive and keeps the
+# recycle. Experimental -- see "Upload reliability" in docs/crash-analysis.md.
+tv_keepalive_interval=0
 # Uploads are normalized before being sent: anything larger than this box is
 # downscaled (aspect preserved, never upscaled) and re-encoded as JPEG. Big
 # payloads make the TV exceed its upload-confirmation window, stranding orphaned

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Related settings:
 | Variable | Default | Applies to | Description |
 |---|---|---|---|
 | `tv_mac_address` | *(unset)* | `sync_thread` | TV MAC address; when set, a Wake-on-LAN packet is sent before retrying a failed connection (`arp -n <tv-ip>` to find it). |
+| `tv_keepalive_interval` | `0` | `sync_thread` | When set (seconds), the TV connection is kept warm with a WebSocket ping whenever it has been idle that long, and the 30s idle-recycle is disabled — so every upload runs on a long-lived connection instead of a brand-new one. `0` disables the keepalive and keeps the recycle. Experimental: this tests whether a warm channel lowers the TV's upload-rejection rate (see `docs/crash-analysis.md`). |
 | `tv_command_delay` | `5.0` | `single_async`, `sync_thread` | Settle delay in seconds inserted between consecutive TV commands: after `upload` before `select_image`, and before deleting the previous image. The Frame needs a moment to finish digesting an upload before it reliably accepts the next command; issuing them back-to-back can crash Art Mode back to regular TV. Set to `0` for the original back-to-back behaviour. |
 | `batch_size` | `50` | `batch_slideshow` | How many images to upload to the TV in one batch. |
 | `batch_rotation_minutes` | `3` | `batch_slideshow` | The TV's own rotation interval, in whole minutes (the TV API only accepts minutes, so `slideshow_interval` does not apply in this mode). |

--- a/docs/crash-analysis.md
+++ b/docs/crash-analysis.md
@@ -78,13 +78,15 @@ The watchdog detects this state (`art_unavailable`) and recycles the connection,
 - **API 5.x** (2023+ models, reported as `5.0.1.0`): the upload mechanism is unchanged, but *event* payloads renamed `value` to `status` (`artmode_status` events). Upstream `samsung-tv-ws-api` fixed this in Dec 2025 (commit `f821d0d2`); our fork (v3.0.5) predates that fix. It only affects the async client's event tracking, so it is dormant while `sync_thread` is in use — but it must be pulled in before relying on `single_async` event handling.
 - **2025 non-Pro Frames**: reported JPEG-only for uploads (one more reason normalization always re-encodes to JPEG).
 
-## Follow-up leads (not yet done)
+## Follow-up leads
 
-1. **Warm-channel experiment against class A.**
-   Every upload currently rides a brand-new connection: the 30 s idle-recycle always fires between 180 s slideshow ticks.
+1. **Warm-channel experiment against class A** *(implemented, results pending)*.
+   Every upload used to ride a brand-new connection: the 30 s idle-recycle always fires between 180 s slideshow ticks.
    Both mature TypeScript implementations (`balmli/com.samsung.smart`, `tavicu/homebridge-samsung-tizen`) instead hold one persistent socket with a keepalive.
-   Test: disable the idle-recycle in favour of a keepalive ping (and/or send one benign request before `send_image`), run a full day, compare the announcement-kill rate against the ~30% baseline.
-   This is the only remaining lever on class A that is under our control.
+   The `tv_keepalive_interval` setting (August 2026) sends a WebSocket ping whenever the `sync_thread` connection has been idle that many seconds and disables the idle-recycle, so uploads run on a long-lived connection.
+   Note the ping only *sends*; no pong is awaited, so a "successful" ping proves the socket accepted the bytes, not that the TV is healthy — a dead peer still surfaces on the next real op, which owns reconnection.
+   Judgement criteria: a full day with `tv_keepalive_interval=15`, comparing the announcement-kill rate (failures at the `ready_to_use` wait) against the ~30% baseline.
+   A fallback variant if the ping alone changes nothing: send one benign art request before `send_image`.
 2. **Trial the `single_async` processor.**
    The upstream maintainer states the async art interface "works much better than the sync interface".
    Prerequisites: pull upstream commit `f821d0d2` (API 5.x event fix) into the fork, then a full-day A/B against `sync_thread`.

--- a/framegallery/config.py
+++ b/framegallery/config.py
@@ -43,6 +43,14 @@ class Settings(BaseSettings):
     # packet before retrying a failed connection. Optional; find it with
     # `arp -n <tv-ip>`. Only helps when the TV is asleep, not for art-mode crashes.
     tv_mac_address: str | None = None
+    # Keep the sync_thread TV connection warm by sending a WebSocket ping whenever it
+    # has been idle this many seconds, instead of tearing it down and rebuilding it
+    # (the 30s idle-recycle). 0 disables the keepalive and keeps the recycle. This is
+    # the "warm channel" experiment from docs/crash-analysis.md: every upload
+    # currently rides a brand-new connection, and the hypothesis is that the TV's
+    # ~30% announcement-kill rate is lower on a long-lived connection, as used by the
+    # mature TypeScript implementations. Applies to the sync_thread processor only.
+    tv_keepalive_interval: float = 0.0
     # Every upload is normalized before it is sent: images larger than this box are
     # downscaled (aspect ratio preserved) and re-encoded as JPEG. The Frame ingests
     # the image on a slow SoC, so payload size directly drives how long an upload

--- a/framegallery/frame_connector/processors/sync_thread.py
+++ b/framegallery/frame_connector/processors/sync_thread.py
@@ -75,6 +75,7 @@ class SyncThreadProcessor(UploadProcessor):
         self._art: SamsungTVArt | None = None
         self._op_lock = asyncio.Lock()
         self._last_used = 0.0
+        self._keepalive_task: asyncio.Task | None = None
 
     # --- lifecycle ---
 
@@ -85,9 +86,11 @@ class SyncThreadProcessor(UploadProcessor):
         await self._connect_client()
         self._connected = True
         self._on_active_image_signal_connect()
+        self._start_keepalive()
 
     async def close(self) -> None:
         """Close the connection and (re)start the reconnection pinger."""
+        self._stop_keepalive()
         await self._close_client()
         self._connected = False
         self._on_active_image_signal_disconnect()
@@ -135,10 +138,70 @@ class SyncThreadProcessor(UploadProcessor):
         if self._art is None:
             await self._connect_client()
             return
+        if self._keepalive_enabled():
+            # The keepalive ping is what keeps the socket from going stale, so the
+            # idle-recycle would only throw away a perfectly warm connection -- and
+            # the whole point of the keepalive is that every TV op (most importantly
+            # the upload announcement) runs on a long-lived connection.
+            return
         if time.monotonic() - self._last_used > self.IDLE_RECYCLE_SECONDS:
             logger.debug("sync_thread: recycling idle connection (idle > %ds)", self.IDLE_RECYCLE_SECONDS)
             await self._close_client()
             await self._connect_client()
+
+    # --- keepalive (the "warm channel" experiment, see docs/crash-analysis.md) ---
+
+    def _keepalive_enabled(self) -> bool:
+        """Whether the WebSocket keepalive replaces the idle-recycle."""
+        return settings.tv_keepalive_interval > 0
+
+    def _start_keepalive(self) -> None:
+        """Start the keepalive loop, if enabled and not already running."""
+        if not self._keepalive_enabled() or self._shutting_down:
+            return
+        if self._keepalive_task is not None and not self._keepalive_task.done():
+            return
+        task = asyncio.create_task(self._keepalive_loop())
+        self._keepalive_task = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    def _stop_keepalive(self) -> None:
+        """Cancel the keepalive loop (idempotent)."""
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            self._keepalive_task = None
+
+    async def _keepalive_loop(self) -> None:
+        """Ping the TV whenever the connection sits idle. A failing ping must not kill the loop."""
+        interval = settings.tv_keepalive_interval
+        logger.info("sync_thread: connection keepalive started (ping after %ss idle)", interval)
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                await self._keepalive_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("sync_thread: keepalive iteration failed; will retry next cycle")
+
+    async def _keepalive_once(self) -> None:
+        """Send one WebSocket ping if the connection has been idle for a full interval."""
+        async with self._op_lock:
+            art = self._art
+            if art is None or art.connection is None:
+                # Not connected right now; the normal reconnect paths own recovery.
+                return
+            if time.monotonic() - self._last_used < settings.tv_keepalive_interval:
+                # Real TV ops are flowing, which keeps the socket warm by itself.
+                return
+            try:
+                await asyncio.to_thread(art.connection.ping)
+            except Exception as exc:  # noqa: BLE001 -- a dead socket here is expected, not exceptional
+                logger.warning("sync_thread: keepalive ping failed (%s); dropping the connection", exc)
+                await self._close_client()
+            else:
+                self._last_used = time.monotonic()
 
     def _wake_tv(self) -> None:
         """Send a Wake-on-LAN packet if a TV MAC address is configured."""

--- a/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
+++ b/tests/unit/framegallery/frame_connector/processors/test_sync_thread.py
@@ -231,6 +231,104 @@ async def test_settle_is_noop_when_delay_zero(processor: SyncThreadProcessor, mo
 
 
 @pytest.mark.asyncio
+async def test_idle_recycle_is_skipped_when_keepalive_is_enabled(
+    processor: SyncThreadProcessor,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """With the keepalive on, an idle connection is kept, not recycled."""
+    monkeypatch.setattr(sync_thread.settings, "tv_keepalive_interval", 15.0)
+    processor._last_used = time.monotonic() - (SyncThreadProcessor.IDLE_RECYCLE_SECONDS + 5)  # noqa: SLF001
+    processor._close_client = AsyncMock()  # noqa: SLF001
+    processor._connect_client = AsyncMock()  # noqa: SLF001
+
+    await processor._ensure_live_client()  # noqa: SLF001
+
+    processor._close_client.assert_not_called()  # noqa: SLF001
+    processor._connect_client.assert_not_called()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_keepalive_pings_an_idle_connection(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """An idle connection gets a WebSocket ping, and the idle clock resets."""
+    monkeypatch.setattr(sync_thread.settings, "tv_keepalive_interval", 15.0)
+    processor._last_used = time.monotonic() - 30  # noqa: SLF001
+
+    await processor._keepalive_once()  # noqa: SLF001
+
+    processor._art.connection.ping.assert_called_once()  # noqa: SLF001
+    assert time.monotonic() - processor._last_used < 1  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_keepalive_skips_a_recently_used_connection(
+    processor: SyncThreadProcessor,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """Real TV ops keep the socket warm by themselves; no ping is added on top."""
+    monkeypatch.setattr(sync_thread.settings, "tv_keepalive_interval", 15.0)
+    processor._last_used = time.monotonic()  # noqa: SLF001
+
+    await processor._keepalive_once()  # noqa: SLF001
+
+    processor._art.connection.ping.assert_not_called()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_keepalive_skips_while_disconnected(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """Without a client there is nothing to ping; reconnection is owned elsewhere."""
+    monkeypatch.setattr(sync_thread.settings, "tv_keepalive_interval", 15.0)
+    processor._art = None  # noqa: SLF001
+
+    await processor._keepalive_once()  # noqa: SLF001 -- must simply do nothing
+
+
+@pytest.mark.asyncio
+async def test_keepalive_ping_failure_drops_the_connection(
+    processor: SyncThreadProcessor,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """A failing ping means a dead socket: close it so the next op reconnects."""
+    monkeypatch.setattr(sync_thread.settings, "tv_keepalive_interval", 15.0)
+    processor._last_used = time.monotonic() - 30  # noqa: SLF001
+    processor._art.connection.ping.side_effect = OSError("broken pipe")  # noqa: SLF001
+    processor._close_client = AsyncMock()  # noqa: SLF001
+
+    await processor._keepalive_once()  # noqa: SLF001
+
+    processor._close_client.assert_awaited_once()  # noqa: SLF001
+
+
+def test_keepalive_is_off_by_default(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """With the default interval of 0, no keepalive task is ever started."""
+    monkeypatch.setattr(sync_thread.settings, "tv_keepalive_interval", 0.0)
+    with patch("framegallery.frame_connector.processors.sync_thread.asyncio.create_task") as create_task:
+        processor._start_keepalive()  # noqa: SLF001
+    create_task.assert_not_called()
+
+
+def test_start_keepalive_is_idempotent_while_running(processor: SyncThreadProcessor, monkeypatch) -> None:  # noqa: ANN001
+    """A second _start_keepalive is a no-op while the loop is still alive."""
+    monkeypatch.setattr(sync_thread.settings, "tv_keepalive_interval", 15.0)
+    running = MagicMock()
+    running.done.return_value = False
+    processor._keepalive_task = running  # noqa: SLF001
+    with patch("framegallery.frame_connector.processors.sync_thread.asyncio.create_task") as create_task:
+        processor._start_keepalive()  # noqa: SLF001
+    create_task.assert_not_called()
+
+
+def test_stop_keepalive_cancels_the_task(processor: SyncThreadProcessor) -> None:
+    """close() must cancel the loop so a reconnect cycle cannot stack loops."""
+    task = MagicMock()
+    processor._keepalive_task = task  # noqa: SLF001
+
+    processor._stop_keepalive()  # noqa: SLF001
+
+    task.cancel.assert_called_once()
+    assert processor._keepalive_task is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_upload_widens_the_socket_timeout_and_restores_it(processor: SyncThreadProcessor) -> None:
     """
     The upload op runs with UPLOAD_CONFIRM_TIMEOUT on the socket, then restores it.


### PR DESCRIPTION
## Summary

The "warm channel" experiment from `docs/crash-analysis.md` (follow-up lead 1).

Roughly a third of uploads fail with the TV killing the art channel in response to the `send_image` announcement, before any image byte is sent. Every one of those uploads rode a brand-new connection: the 30 s idle-recycle always fires between 180 s slideshow ticks, so the upload announcement is always the first real request on a cold channel — while other request types on equally cold channels fail only ~2–3% of the time. The mature TypeScript Frame implementations hold one persistent socket with a keepalive instead; this makes that behaviour available behind a setting so it can be A/B tested in production without a rebuild.

## Changes

- New setting `tv_keepalive_interval` (seconds, default `0` = off, behaviour unchanged). When set, `sync_thread`:
  - sends a WebSocket ping whenever the connection has been idle that long (under the op lock; skipped while real ops are flowing);
  - skips the 30 s idle-recycle, so uploads run on a long-lived warm connection.
- A failed ping drops the client so the next op reconnects lazily. The loop starts on `open()`, is cancelled on `close()`, and cannot stack across reconnect cycles.
- The ping only *sends* — no pong is awaited — so it prevents idle-socket staleness rather than proving TV health; a dead peer still surfaces on the next real op, which owns reconnection.
- README, `.env.dist`, and `docs/crash-analysis.md` updated (lead 1 marked implemented, with judgement criteria).

## Experiment protocol

Set `tv_keepalive_interval=15`, recreate the container, run a **full day** (several hundred uploads), then compare the announcement-kill rate (upload failures at the `ready_to_use` wait) against the ~30% baseline. Anything shorter than a day is noise.

## Testing

- 8 new unit tests: idle-recycle skipped when enabled, ping on idle / skip when busy / skip when disconnected, ping failure drops the client, off by default, loop idempotence, and cancellation on close.
- `uv run pytest` — 259 passed; `uv run ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)